### PR TITLE
Re-throw caught exceptions when streaming a package.

### DIFF
--- a/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AbstractThreadedOutputStreamWriter.java
+++ b/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AbstractThreadedOutputStreamWriter.java
@@ -198,6 +198,14 @@ public abstract class AbstractThreadedOutputStreamWriter extends Thread {
             if (closeStreamHandler != null) {
                 closeStreamHandler.closeAll();
             }
+
+            // Must re-throw this exception when an error occurs streaming the package so that the caller knows to
+            // fail the deposit
+            if (e instanceof RuntimeException) {
+                throw (RuntimeException) e;
+            } else {
+                throw new RuntimeException(e);
+            }
         }
     }
 

--- a/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AbstractZippedPackageStream.java
+++ b/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AbstractZippedPackageStream.java
@@ -79,6 +79,8 @@ public abstract class AbstractZippedPackageStream implements PackageStream {
         // stack trace of the exception will be reported when it is encountered by the reader
         Thread.UncaughtExceptionHandler exceptionHandler = (t, e) -> {
             // Make the exception caught by the writer available to the reader; set it on the PipedInputStream
+            // The reader will use this to close any resources it has open when an exception occurs, and allow the
+            // thread to be cleaned up.
             pipedIn.setWriterEx(e);
         };
 


### PR DESCRIPTION
Re-throw any exceptions caught when streaming the package, so the caller can handle it.

Right now, if streaming the package fails for some reason, the status of the corresponding `Deposit` won't be properly updated to `FAILED`.  Re-throwing the exception allows the caller to handle properly update the `Deposit` status.