### PR TITLE
Use release version of PASS client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <sword2-client.version>0.9.3</sword2-client.version>
         <mets-api.version>1.3.0</mets-api.version>
         <tika.version>1.17</tika.version>
-        <pass-client.version>0.3.4-SNAPSHOT</pass-client.version>
+        <pass-client.version>0.3.5</pass-client.version>
         <fast-classpath-scanner.version>3.1.5</fast-classpath-scanner.version>
         <jackson.version>2.9.6</jackson.version>
 


### PR DESCRIPTION
No longer depend on the `-SNAPSHOT`, as the java client has been properly released to Maven central.  

This is a prerequisite to using the release plugin for managing deposit services releases.