### PR TITLE
Fix DSpace metadata issues and add unit tests for metadata

### DIFF
--- a/deposit-model/src/main/java/org/dataconservancy/pass/deposit/model/DepositMetadata.java
+++ b/deposit-model/src/main/java/org/dataconservancy/pass/deposit/model/DepositMetadata.java
@@ -363,6 +363,21 @@ public class DepositMetadata {
         }
 
         /**
+         * Returns the assembled name for the person using the first/middle/last names.
+         * @return the complete name for the person, or empty string if first or last are missing.
+         */
+        public String getConstructedName() {
+            if (getFirstName() != null && getLastName() != null) {
+                if (getMiddleName() != null) {
+                    return String.format("%s %s %s", getFirstName(), getMiddleName(), getLastName());
+                } else {
+                    return String.format("%s %s", getFirstName(), getLastName());
+                }
+            }
+            return "";
+        }
+
+        /**
          * Returns the "total" name for the person, regardless of how that name was supplied.
          * If a "full" name (single string) was supplied, it will be returned.
          * Otherwise, a name will be constructed from the supplied first/middle/last names.
@@ -371,14 +386,9 @@ public class DepositMetadata {
         public String getName() {
             if (getFullName() != null) {
                 return getFullName();
-            } else if (getFirstName() != null && getLastName() != null) {
-                if (getMiddleName() != null) {
-                    return String.format("%s %s %s", getFirstName(), getMiddleName(), getLastName());
-                } else {
-                    return String.format("%s %s", getFirstName(), getLastName());
-                }
+            } else {
+                return getConstructedName();
             }
-            return "";
         }
 
         /**

--- a/dspace-mets-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/DspaceMetadataDomWriterTest.java
+++ b/dspace-mets-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/DspaceMetadataDomWriterTest.java
@@ -423,27 +423,37 @@ public class DspaceMetadataDomWriterTest {
      */
     @Test
     public void testCreateDublinCoreMetadata() throws Exception {
-        DepositMetadata md = mock(DepositMetadata.class);
         DepositMetadata.Manuscript msMd = mock(DepositMetadata.Manuscript.class);
         String msAbs = "This is the manuscript abstract";
         when(msMd.getMsAbstract()).thenReturn(msAbs);
         String msTitle = "This is the manuscript title.";
         when(msMd.getTitle()).thenReturn(msTitle);
+
         DepositMetadata.Article artMd = mock(DepositMetadata.Article.class);
         when(artMd.getTitle()).thenReturn("This is the article title");
         ZonedDateTime embargoLiftDate = ZonedDateTime.now().plusDays(10);
         when(artMd.getEmbargoLiftDate()).thenReturn(embargoLiftDate);
         String artDoi = "http://dx.doi.org/1234";
         when(artMd.getDoi()).thenReturn(URI.create(artDoi));
+
+        DepositMetadata.Journal jMd = mock(DepositMetadata.Journal.class);
+        String publisherName = "Big Publisher";
+        when(jMd.getPublisherName()).thenReturn(publisherName);
+        String publicationDate = "1/9/1919";
+        when(jMd.getPublicationDate()).thenReturn(publicationDate);
+
+        DepositMetadata md = mock(DepositMetadata.class);
         when(md.getArticleMetadata()).thenReturn(artMd);
         when(md.getManuscriptMetadata()).thenReturn(msMd);
+        when(md.getJournalMetadata()).thenReturn(jMd);
         DepositSubmission submission = mock(DepositSubmission.class);
         when(submission.getMetadata()).thenReturn(md);
 
         // Only Jane Doe (author) will appear in the citation.
         DepositMetadata.Person person1 = createMockPerson(null, null, null, "Jane Doe", DepositMetadata.PERSON_TYPE.author);
         DepositMetadata.Person person2 = createMockPerson("John", null, "Doe", null, DepositMetadata.PERSON_TYPE.pi);
-        List<DepositMetadata.Person> contributors = Arrays.asList(person1, person2);
+        DepositMetadata.Person person3 = createMockPerson(null, null, null, "Hulk Hogan", DepositMetadata.PERSON_TYPE.pi);
+        List<DepositMetadata.Person> contributors = Arrays.asList(person1, person2, person3);
         when(md.getPersons()).thenReturn(contributors);
 
         underTest.mapDmdSec(submission);
@@ -466,7 +476,7 @@ public class DspaceMetadataDomWriterTest {
         Element qdc = (Element)mdWrap.getFirstChild().getFirstChild();
         assertEquals("qualifieddc", qdc.getTagName());
 
-        assertEquals(2, qdc.getElementsByTagNameNS(DC_NS, DC_CONTRIBUTOR).getLength());
+        assertEquals(3, qdc.getElementsByTagNameNS(DC_NS, DC_CONTRIBUTOR).getLength());
         Element contributor1 = (Element) qdc.getElementsByTagNameNS(DC_NS, DC_CONTRIBUTOR).item(0);
         Element contributor2 = (Element) qdc.getElementsByTagNameNS(DC_NS, DC_CONTRIBUTOR).item(1);
         assertEquals("Jane Doe", contributor1.getTextContent());

--- a/dspace-mets-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/DspaceMetadataDomWriterTest.java
+++ b/dspace-mets-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/DspaceMetadataDomWriterTest.java
@@ -151,6 +151,7 @@ public class DspaceMetadataDomWriterTest {
                                                     DepositMetadata.PERSON_TYPE type) {
         DepositMetadata.Person contributor = mock(DepositMetadata.Person.class);
         when(contributor.getName()).thenCallRealMethod();
+        when(contributor.getConstructedName()).thenCallRealMethod();
         when(contributor.getReversedName()).thenCallRealMethod();
 
         if (first != null)

--- a/dspace-mets-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/MetadataTest.java
+++ b/dspace-mets-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/MetadataTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.pass.deposit.assembler.dspace.mets;
+
+import org.dataconservancy.pass.deposit.builder.fs.FilesystemModelBuilder;
+import org.dataconservancy.pass.deposit.model.DepositSubmission;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Element;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.net.URI;
+
+import static java.util.Collections.emptyMap;
+import static org.dataconservancy.pass.deposit.assembler.dspace.mets.XMLConstants.DCTERMS_NS;
+import static org.dataconservancy.pass.deposit.assembler.dspace.mets.XMLConstants.DCT_BIBLIOCITATION;
+import static org.dataconservancy.pass.deposit.assembler.dspace.mets.XMLConstants.DC_PUBLISHER;
+import static org.dataconservancy.pass.deposit.assembler.dspace.mets.XMLConstants.DC_CONTRIBUTOR;
+import static org.dataconservancy.pass.deposit.assembler.dspace.mets.XMLConstants.DC_NS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static submissions.SubmissionResourceUtil.lookupStream;
+
+/**
+ * Tests the transport of metadata from a Submission Fedora resource through the
+ * deposit services data model and on to the DSpace XML that is suitable for JScholarship.
+ */
+public class MetadataTest {
+
+    private DspaceMetadataDomWriter domWriter;
+    private FilesystemModelBuilder modelBuilder;
+
+    private static final URI SUBMISSION_RESOURCE_1 = URI.create("fake:submission12");
+    private static final URI SUBMISSION_RESOURCE_2 = URI.create("fake:submission13");
+
+    @Before
+    public void setup() {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        domWriter = new DspaceMetadataDomWriter(dbf);
+        modelBuilder = new FilesystemModelBuilder();
+    }
+
+    @Test
+    public void commonContributorsAndFewAuthors() throws Exception {
+        // Create deposit services data model from JSON representing Submission
+        DepositSubmission depositSubmission = modelBuilder.build(lookupStream(SUBMISSION_RESOURCE_1), emptyMap());
+        // Create XML DOM for DSpace metadata from deposit services data model
+        Element qdc = domWriter.createDublinCoreMetadataDCMES(depositSubmission);
+
+        // Take publisher from "common" if not in "crossref".
+        assertNotNull(qdc.getElementsByTagNameNS(DC_NS, DC_PUBLISHER).item(0).getTextContent());
+        assertEquals("Elsevier", qdc.getElementsByTagNameNS(DC_NS, DC_PUBLISHER).item(0).getTextContent());
+
+        // Contributor list does not include submitting user, only PIs (from Grant) and authors (from metadata)
+        assertEquals(4, qdc.getElementsByTagNameNS(DC_NS, DC_CONTRIBUTOR).getLength());
+        for (int i = 0; i < 3; i++) {
+            // Contributors must have names, whether they come from
+            // first/middle/last or only display name (in Submission), or from metadata.
+            Element contributor = (Element) qdc.getElementsByTagNameNS(DC_NS, DC_CONTRIBUTOR).item(i);
+            assertNotEquals("", contributor.getTextContent());
+        }
+
+        // In citation, list up to three authors.  Take publication date from "common" if not in "crossref".
+        assertNotNull(qdc.getElementsByTagNameNS(DCTERMS_NS, DCT_BIBLIOCITATION).item(0).getTextContent());
+        assertEquals("Christine Cagney, Mary Beth Lacey. (Fall 2016). \"My Test Article.\" Nature Communications.",
+                qdc.getElementsByTagNameNS(DCTERMS_NS, DCT_BIBLIOCITATION).item(0).getTextContent());
+    }
+
+
+    @Test
+    public void crossrefAndManyAuthors() throws Exception {
+        // Create deposit services data model from JSON representing Submission
+        DepositSubmission depositSubmission = modelBuilder.build(lookupStream(SUBMISSION_RESOURCE_2), emptyMap());
+        // Create XML DOM for DSpace metadata from deposit services data model
+        Element qdc = domWriter.createDublinCoreMetadataDCMES(depositSubmission);
+
+        // Publisher name in "crossref" has precedence over one in "common".
+        assertNotNull(qdc.getElementsByTagNameNS(DC_NS, DC_PUBLISHER).item(0).getTextContent());
+        assertEquals("Springer", qdc.getElementsByTagNameNS(DC_NS, DC_PUBLISHER).item(0).getTextContent());
+
+        // In citation, use "et al" for more than three authors.
+        // Publication date in "crossref" has precedence over one in "common".
+        assertNotNull(qdc.getElementsByTagNameNS(DCTERMS_NS, DCT_BIBLIOCITATION).item(0).getTextContent());
+        String foo = qdc.getElementsByTagNameNS(DCTERMS_NS, DCT_BIBLIOCITATION).item(0).getTextContent();
+        assertEquals("Christine Cagney, Mary Beth Lacey, David Michael Starsky, et al. (Spring 2018). \"My Test Article.\" Nature Communications.",
+                qdc.getElementsByTagNameNS(DCTERMS_NS, DCT_BIBLIOCITATION).item(0).getTextContent());
+    }
+}

--- a/nihms-native-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/assembler/nihmsnative/NihmsAssemblerIT.java
+++ b/nihms-native-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/assembler/nihmsnative/NihmsAssemblerIT.java
@@ -208,7 +208,8 @@ public class NihmsAssemblerIT extends BaseAssemblerIT {
         // Insure that the Person in the metadata matches a Person on the Submission, and that the person is a corresponding pi
         asPersons.stream().forEach(person -> {
             assertTrue(submission.getMetadata().getPersons().stream().anyMatch(candidate ->
-                    candidate.getName().equals(person.getName()) &&
+                    // NIHMS metadata only use first/last/middle names, so never compare against the "full" version
+                    candidate.getConstructedName().equals(person.getName()) &&
                     candidate.getType() == person.getType()));
         });
 

--- a/shared-resources/src/test/resources/submissions/sample-metadata1.json
+++ b/shared-resources/src/test/resources/submissions/sample-metadata1.json
@@ -1,0 +1,134 @@
+[
+  {
+    "metadata" : "[{\"id\" : \"JScholarship\", \"data\" : {\"authors\" : [{\"author\" : \"Christine Cagney\"},{\"author\" : \"Mary Beth Lacey\"}], \"embargo\" : \"Text removed.\", \"agreement-to-deposit\" : \"true\"}},{ \"id\" : \"common\", \"data\" : {\"title\" : \"My Test Article\",\"journal-title\":\"Nature Communications\",\"ISSN\":\"2041-1723\",\"publisher\":\"Elsevier\",\"publicationDate\":\"Fall 2016\",\"abstract\":\"Abstract text\",\"authors\":[{\"author\" : \"Christine Cagney\"},{\"author\" : \"Mary Beth Lacey\"}]} },{ \"id\":\"crossref\", \"data\":{} },{ \"id\":\"pmc\", \"data\":{\"nlmta\":\"Nat Commun\"} },{ \"id\":\"agent_information\", \"data\":{\"information\":{\"name\":\"Chrome\",\"version\":\"69\"}} }]",
+    "source" : "pass",
+    "submitted" : true,
+    "submittedDate" : "2017-06-02T00:00:00.000Z",
+    "aggregatedDepositStatus" : "not-started",
+    "publication" : "fake:publication1",
+    "repositories" : [ "fake:repository1", "fake:repository2" ],
+    "user" : "fake:user2",
+    "grants" : [ "fake:grant1" ],
+    "@id" : "fake:submission12",
+    "@type" : "Submission"
+  },
+  {
+    "title" : "This is the first submission",
+    "abstract" : "This is a great paper!",
+    "doi" : "abcdef",
+    "pmid" : "fedcba",
+    "journal" : "fake:journal1",
+    "volume" : "123",
+    "issue" : "May 2015",
+    "@id" : "fake:publication1",
+    "@type" : "Publication"
+  },
+  {
+    "name" : "AAPS PharmSci",
+    "issns" : [ "issn123", "issn456" ],
+    "nlmta" : "AAPS PharmSci",
+    "pmcParticipation" : "A",
+    "publisher" : "",
+    "@id" : "fake:journal1",
+    "@type" : "Journal"
+  },
+  {
+    "name" : "PubMed Central",
+    "repositoryKey" : "PubMed Central",
+    "description" : "Contains lots of medical papers",
+    "url" : "http://example.com",
+    "formSchema" : "{}",
+    "@id" : "fake:repository1",
+    "@type" : "Repository"
+  },
+  {
+    "name" : "JScholarship",
+    "repositoryKey" : "JScholarship",
+    "description" : "Knowledge for the world",
+    "url" : "http://j10p.com",
+    "formSchema" : "{}",
+    "@id" : "fake:repository2",
+    "@type" : "Repository"
+  },
+  {
+    "awardNumber" : "R01EY026617",
+    "awardStatus" : "active",
+    "localKey" : "112233",
+    "projectName" : "Optimal magnification and oculomotor strategies in low vision patients",
+    "awardDate" : "2017-06-01T00:00:00.000Z",
+    "startDate" : "2017-05-01T00:00:00.000Z",
+    "endDate" : "2018-06-01T00:00:00.000Z",
+    "primaryFunder" : "fake:funder1",
+    "directFunder" : "fake:funder2",
+    "pi" : "fake:user2",
+    "coPis" : [ "fake:user3" ],
+    "@id" : "fake:grant1",
+    "@type" : "Grant"
+  },
+  {
+    "name" : "National Eye Institute",
+    "url" : "http://example.com/eyeguys",
+    "localKey" : "aabbcc",
+    "policy" : "fake:policy1",
+    "@id" : "fake:funder1",
+    "@type" : "Funder"
+  },
+  {
+    "title" : "Be Nice to People With Eyes",
+    "description" : "We only have eyes for you.",
+    "policyUrl" : "http://theeyeshaveit.com/policy",
+    "repositories" : [ "fake:repository1" ],
+    "institution" : "fake:institution1",
+    "funder" : "fake:funder1",
+    "@id" : "fake:policy1",
+    "@type" : "Policy"
+  },
+  {
+    "name" : "International Eye Institute",
+    "url" : "http://example.com/othereyeguys",
+    "localKey" : "ddeeff",
+    "policy" : "fake:policy1",
+    "@id" : "fake:funder2",
+    "@type" : "Funder"
+  },
+  {
+    "username" : "bobsmith",
+    "firstName" : "Robert",
+    "lastName" : "Smith",
+    "displayName" : "Bob Smith",
+    "email" : "bobsmith@jhu.edu",
+    "affiliation" : "Johns Hopkins",
+    "institutionalId" : "bs1",
+    "localKey" : "key123",
+    "orcidId" : "orcid123",
+    "roles" : [ "submitter" ],
+    "@id" : "fake:user1",
+    "@type" : "User"
+  },
+  {
+    "username" : "suzyv",
+    "firstName" : "Suzanne",
+    "middleName" : "X",
+    "lastName" : "Vega",
+    "email" : "suzannev@jhu.edu",
+    "affiliation" : "Johns Hopkins",
+    "institutionalId" : "sxv3",
+    "localKey" : "keyabc",
+    "orcidId" : "orc456",
+    "roles" : [ "admin" ],
+    "@id" : "fake:user2",
+    "@type" : "User"
+  },
+  {
+    "username" : "johndoe",
+    "displayName" : "John Doe",
+    "email" : "jd@jhu.edu",
+    "affiliation" : "Johns Hopkins",
+    "institutionalId" : "jd123",
+    "localKey" : "keyabc123",
+    "orcidId" : "orc789",
+    "roles" : [ "submitter", "admin" ],
+    "@id" : "fake:user3",
+    "@type" : "User"
+  }
+]

--- a/shared-resources/src/test/resources/submissions/sample-metadata2.json
+++ b/shared-resources/src/test/resources/submissions/sample-metadata2.json
@@ -1,0 +1,134 @@
+[
+  {
+    "metadata":"[{\"id\":\"JScholarship\",\"data\":{\"authors\":[{\"author\":\"Christine Cagney\"},{\"author\":\"Mary Beth Lacey\"},{\"author\":\"David Michael Starsky\"},{\"author\":\"Kenneth Richard Hutchinson\"}],\"embargo\":\"Text removed.\",\"agreement-to-deposit\":\"true\"}},{\"id\":\"common\",\"data\":{\"title\":\"My Test Article\",\"journal-title\":\"Nature Communications\",\"ISSN\":\"2041-1723\",\"publisher\":\"Elsevier\",\"publicationDate\":\"Fall 2016\",\"abstract\":\"Abstract text\",\"authors\":[{\"author\":\"Christine Cagney\"},{\"author\":\"Mary Beth Lacey\"},{\"author\":\"David Michael Starsky\"},{\"author\":\"Kenneth Richard Hutchinson\"}]}},{\"id\":\"crossref\",\"data\":{\"publisher\":\"Springer\",\"publicationDate\":\"Spring 2018\"}},{\"id\":\"pmc\",\"data\":{\"nlmta\":\"Nat Commun\"}},{\"id\":\"agent_information\",\"data\":{\"information\":{\"name\":\"Chrome\",\"version\":\"69\"}}}]",
+    "source" : "pass",
+    "submitted" : true,
+    "submittedDate" : "2017-06-02T00:00:00.000Z",
+    "aggregatedDepositStatus" : "not-started",
+    "publication" : "fake:publication1",
+    "repositories" : [ "fake:repository1", "fake:repository2" ],
+    "user" : "fake:user2",
+    "grants" : [ "fake:grant1" ],
+    "@id" : "fake:submission13",
+    "@type" : "Submission"
+  },
+  {
+    "title" : "This is the first submission",
+    "abstract" : "This is a great paper!",
+    "doi" : "abcdef",
+    "pmid" : "fedcba",
+    "journal" : "fake:journal1",
+    "volume" : "123",
+    "issue" : "May 2015",
+    "@id" : "fake:publication1",
+    "@type" : "Publication"
+  },
+  {
+    "name" : "AAPS PharmSci",
+    "issns" : [ "issn123", "issn456" ],
+    "nlmta" : "AAPS PharmSci",
+    "pmcParticipation" : "A",
+    "publisher" : "",
+    "@id" : "fake:journal1",
+    "@type" : "Journal"
+  },
+  {
+    "name" : "PubMed Central",
+    "repositoryKey" : "PubMed Central",
+    "description" : "Contains lots of medical papers",
+    "url" : "http://example.com",
+    "formSchema" : "{}",
+    "@id" : "fake:repository1",
+    "@type" : "Repository"
+  },
+  {
+    "name" : "JScholarship",
+    "repositoryKey" : "JScholarship",
+    "description" : "Knowledge for the world",
+    "url" : "http://j10p.com",
+    "formSchema" : "{}",
+    "@id" : "fake:repository2",
+    "@type" : "Repository"
+  },
+  {
+    "awardNumber" : "R01EY026617",
+    "awardStatus" : "active",
+    "localKey" : "112233",
+    "projectName" : "Optimal magnification and oculomotor strategies in low vision patients",
+    "awardDate" : "2017-06-01T00:00:00.000Z",
+    "startDate" : "2017-05-01T00:00:00.000Z",
+    "endDate" : "2018-06-01T00:00:00.000Z",
+    "primaryFunder" : "fake:funder1",
+    "directFunder" : "fake:funder2",
+    "pi" : "fake:user2",
+    "coPis" : [ "fake:user3" ],
+    "@id" : "fake:grant1",
+    "@type" : "Grant"
+  },
+  {
+    "name" : "National Eye Institute",
+    "url" : "http://example.com/eyeguys",
+    "localKey" : "aabbcc",
+    "policy" : "fake:policy1",
+    "@id" : "fake:funder1",
+    "@type" : "Funder"
+  },
+  {
+    "title" : "Be Nice to People With Eyes",
+    "description" : "We only have eyes for you.",
+    "policyUrl" : "http://theeyeshaveit.com/policy",
+    "repositories" : [ "fake:repository1" ],
+    "institution" : "fake:institution1",
+    "funder" : "fake:funder1",
+    "@id" : "fake:policy1",
+    "@type" : "Policy"
+  },
+  {
+    "name" : "International Eye Institute",
+    "url" : "http://example.com/othereyeguys",
+    "localKey" : "ddeeff",
+    "policy" : "fake:policy1",
+    "@id" : "fake:funder2",
+    "@type" : "Funder"
+  },
+  {
+    "username" : "bobsmith",
+    "firstName" : "Robert",
+    "lastName" : "Smith",
+    "displayName" : "Bob Smith",
+    "email" : "bobsmith@jhu.edu",
+    "affiliation" : "Johns Hopkins",
+    "institutionalId" : "bs1",
+    "localKey" : "key123",
+    "orcidId" : "orcid123",
+    "roles" : [ "submitter" ],
+    "@id" : "fake:user1",
+    "@type" : "User"
+  },
+  {
+    "username" : "suzyv",
+    "firstName" : "Suzanne",
+    "middleName" : "X",
+    "lastName" : "Vega",
+    "email" : "suzannev@jhu.edu",
+    "affiliation" : "Johns Hopkins",
+    "institutionalId" : "sxv3",
+    "localKey" : "keyabc",
+    "orcidId" : "orc456",
+    "roles" : [ "admin" ],
+    "@id" : "fake:user2",
+    "@type" : "User"
+  },
+  {
+    "username" : "johndoe",
+    "displayName" : "John Doe",
+    "email" : "jd@jhu.edu",
+    "affiliation" : "Johns Hopkins",
+    "institutionalId" : "jd123",
+    "localKey" : "keyabc123",
+    "orcidId" : "orc789",
+    "roles" : [ "submitter", "admin" ],
+    "@id" : "fake:user3",
+    "@type" : "User"
+  }
+]


### PR DESCRIPTION
Deposit Services issue 165 points out a couple of problems with the way submission metadata is presented in DSpace deposit metadata.  This change fixes those issues and adds two unit tests that cover the path of metadata from Submission resource through the deposit services data model to the DSpace XML metadata.

Specific fixes are to:
* Make sure the publisher name is included in the output when it is specified in either the "common" or "crossref" sections of the metadata, with crossref taking precedence.
* Use the publication date from either the common or crossref metadata sections when creating the output metadata's citation entry.
* Use a single "display" name value for PI contributor entries when the first/middle/last names are not provided.
* Extend an existing unit test to include data like that which was causing problems.

The two new tests use two new sample data sets (JSON representations of Submission resources with metadata).  The first test tests the cases of:
* Publisher name and publication date being specified only in the common metadata section
* Submitters not generating contributor entries.
* Citation format for three or fewer authors.

The second test covers the cases of:
* Publisher name and publication date specified in the crossref metadata section.
* Citation format for four or more authors.

resolves https://github.com/OA-PASS/deposit-services/issues/165