### PR TITLE
Annotate ITs using DrainQueueConfig with DirtiesContext

### DIFF
--- a/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/builder/fedora/FcrepoModelBuilderIT.java
+++ b/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/builder/fedora/FcrepoModelBuilderIT.java
@@ -40,6 +40,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.InputStream;
@@ -53,6 +54,7 @@ import java.util.Map;
 @SpringBootTest(classes = DepositConfig.class)
 @ComponentScan("org.dataconservancy.pass.deposit")
 @Import(DrainQueueConfig.class)
+@DirtiesContext
 public class FcrepoModelBuilderIT {
 
     private static final String EXPECTED_JOURNAL_TITLE = "Food & Function";

--- a/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/builder/fedora/PassJsonFedoraAdapterIT.java
+++ b/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/builder/fedora/PassJsonFedoraAdapterIT.java
@@ -32,6 +32,7 @@ import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.File;
@@ -52,6 +53,7 @@ import static submissions.SubmissionResourceUtil.lookupStream;
 @SpringBootTest(classes = DepositConfig.class)
 @ComponentScan("org.dataconservancy.pass.deposit")
 @Import(DrainQueueConfig.class)
+@DirtiesContext
 public class PassJsonFedoraAdapterIT {
 
     private URI SAMPLE_DATA_FILE = URI.create("fake:submission1");

--- a/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/messaging/PassClientIT.java
+++ b/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/messaging/PassClientIT.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.net.URI;
@@ -38,6 +39,7 @@ import static org.junit.Assert.assertNotNull;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @Import(DrainQueueConfig.class)
+@DirtiesContext
 public class PassClientIT {
 
     @Autowired

--- a/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/messaging/service/EmptySubmissionIT.java
+++ b/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/messaging/service/EmptySubmissionIT.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import submissions.SubmissionResourceUtil;
 
@@ -36,6 +37,7 @@ import static org.hamcrest.CoreMatchers.isA;
 @SpringBootTest
 @RunWith(SpringRunner.class)
 @Import({DepositConfig.class, DrainQueueConfig.class})
+@DirtiesContext
 public class EmptySubmissionIT extends AbstractSubmissionIT {
 
     private static final URI SUBMISSION_RESOURCES = URI.create("fake:submission10");

--- a/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/messaging/status/AbderaClientHttpsIT.java
+++ b/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/messaging/status/AbderaClientHttpsIT.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.junit.Assert.assertEquals;
@@ -74,6 +75,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @Import(DrainQueueConfig.class)
+@DirtiesContext
 @Ignore("To be run manually, see class Javadoc.")
 public class AbderaClientHttpsIT {
 

--- a/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/messaging/support/CriticalPathIT.java
+++ b/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/messaging/support/CriticalPathIT.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.junit.Assert.assertEquals;
@@ -41,6 +42,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(SpringRunner.class)
 @SpringBootTest(properties = { "spring.jms.listener.auto-startup=false" })
 @Import(DrainQueueConfig.class)
+@DirtiesContext
 public class CriticalPathIT {
 
     @Autowired

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/spring/DrainQueueConfig.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/spring/DrainQueueConfig.java
@@ -29,6 +29,28 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.Session;
 
+/**
+ * Provides a JMS listener which immediately {@link Message#acknowledge() acknowledge} each message received for its
+ * configured queue or topic.  Effectively the listener will absorb any JMS messages without invoking any other
+ * business logic.
+ * <p>
+ * This is useful, for example, when an executing IT produces JMS messages as a byproduct of test execution.  The IT may
+ * not be interested at all in the JMS messages produced - they just occur as side affect of manipulating resources in
+ * the Fedora repository, for example.
+ * </p>
+ * <p>
+ * When {@code DrainQueueConfig} is introduced, it will connect to the {@code deposit} and {@code submission} queues.
+ * The included {@code JmsListenerContainerFactory} insures the the listeners are started automatically, and set the
+ * correct acknowledgement mode.
+ * </p>
+ * <p>
+ * Importantly, {@code DrainQueueConfig} will conflict with {@link JmsConfig} if they are both present in a Spring
+ * Application Context.  Only one or the other should be present.  Concretely, once an IT introduces
+ * {@code DrainQueueConfig} into the Spring Application Context, it will be present in the context until removed.  To
+ * easily avoid this issue, a good rule of thumb is: <em>If an IT uses {@code DrainQueueConfig}, the IT ought to
+ * annotate the class as {@code DirtiesContext}</em>
+ * </p>
+ */
 @EnableJms
 public class DrainQueueConfig {
     private static final Logger LOG = LoggerFactory.getLogger(DrainQueueConfig.class);


### PR DESCRIPTION
Most, if not all, ITs in Deposit Services produce JMS messages as a byproduct of interacting with Fedora.

Some ITs invoke production business logic that process the produced messages.  Other ITs will produce messages, but no business logic is invoked to process the messages (for example, an IT may simply create a resource in Fedora as part of a test fixture without processing messages produced by the resource creation).

If an IT does not process (in the case of the former scenario) or clean up (in the latter scenario) the JMS messages it produces, they will carry over to the next test and that test may produce erroneous results.  There are two configurations that support either mode: `JmsConfig` in the case of the former scenario, and `DrainQueueConfig` in the latter.

`JmsConfig` and `DrainQueueConfig` will compete to read messages if they are both present in the Spring Application Context.  If both are present in the Application Context, JMS messages will appear to go missing, and tests that rely on the processing of messages will fail when they ought to otherwise succeed.

This PR insures that when `DrainQueueConfig` is introduced into the Application Context, it marks the context as dirty with `DirtiesContext`.  This insures that the Application Context will be rebuilt from scratch for the next test.  Since `DrainQueueConfig` is excluded from the Application Context by default, the newly built Application Context will only contain `JmsConfig`.

Note that when an IT includes `DrainQueueConfig` (e.g. with `@Import`),  _both_ JMS configurations are present in the Application Context.  This will be OK for those tests that include `@DrainQueueConfig`, because the end goal is for the JMS message to be acknowledged.  If `JmsConfig` acknowledges the message before `DrainQueueConfig`, that is OK.


Closes #168.