### PR TITLE
Bump to model 3.2

### DIFF
--- a/fedora-builder/src/main/java/org/dataconservancy/pass/deposit/builder/fs/ModelBuilder.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/pass/deposit/builder/fs/ModelBuilder.java
@@ -336,7 +336,17 @@ abstract class ModelBuilder {
         submission.setName(submissionEntity.getId().toString());
 
         // Data from the Submission's user resource
+      
+        if (submissionEntity.getSubmitter() == null) {
+            throw new InvalidModel("Submitter is undefined for submission " + submissionEntity.getId());
+        }
+        
         User userEntity = (User)entities.get(submissionEntity.getSubmitter());
+        
+        if (userEntity == null) {
+            throw new InvalidModel("Could not find User entity for " + submissionEntity.getSubmitter());
+        }
+        
         persons.add(createPerson(userEntity, DepositMetadata.PERSON_TYPE.submitter));
 
         // As of 5/14/18, the following data is available from both the Submission metadata

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <docker.dspace.version>oapass/dspace:latest</docker.dspace.version>
         <docker.ftp.version>oapass/ftpserver:latest</docker.ftp.version>
 
-        <pass.jsonld.context>https://oa-pass.github.io/pass-data-model/src/main/resources/context-3.1.jsonld</pass.jsonld.context>
+        <pass.jsonld.context>https://oa-pass.github.io/pass-data-model/src/main/resources/context-3.2.jsonld</pass.jsonld.context>
 
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -100,13 +100,13 @@
         <sword2-client.version>0.9.3</sword2-client.version>
         <mets-api.version>1.3.0</mets-api.version>
         <tika.version>1.17</tika.version>
-        <pass-client.version>0.4.2</pass-client.version>
+        <pass-client.version>0.5.0</pass-client.version>
         <fast-classpath-scanner.version>3.1.5</fast-classpath-scanner.version>
         <jackson.version>2.9.6</jackson.version>
         <messaging-support.version>0.1.0-3.1-SNAPSHOT</messaging-support.version>
 
-        <docker.fcrepo.version>oapass/fcrepo:4.7.5-3.1-SNAPSHOT</docker.fcrepo.version>
-        <docker.indexer.version>oapass/indexer:0.0.15-3.1-SNAPSHOT</docker.indexer.version>
+        <docker.fcrepo.version>oapass/fcrepo:4.7.5-3.2-2</docker.fcrepo.version>
+        <docker.indexer.version>oapass/indexer:0.0.17-3.2-SNAPSHOT</docker.indexer.version>
         <docker.elasticsearch.version>docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.3</docker.elasticsearch.version>
 
         <!-- TODO properly tag these images -->


### PR DESCRIPTION
Bumps the client, and context, as well as fcrepo and indexer versions for ITs.

Adds some code to defend against null submitters, though it's unclear that such a condition would be possible (i.e. it is likely the submission would not be considered by DS in the first place)

Resolves #171