### PR TITLE
Make it clear when deposits fail due to a missing Repository configuration

### DIFF
--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/RemedialDepositException.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/RemedialDepositException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging;
+
+import org.dataconservancy.pass.model.PassEntity;
+
+/**
+ * An exception that can be remediated, for example, by correcting a problem with the runtime configuration of Deposit
+ * Services or one of its components.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class RemedialDepositException extends DepositServiceRuntimeException {
+
+    public RemedialDepositException(PassEntity resource) {
+        super(resource);
+    }
+
+    public RemedialDepositException(String message, PassEntity resource) {
+        super(message, resource);
+    }
+
+    public RemedialDepositException(String message, Throwable cause, PassEntity resource) {
+        super(message, cause, resource);
+    }
+
+    public RemedialDepositException(Throwable cause, PassEntity resource) {
+        super(cause, resource);
+    }
+
+}

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/spring/JmsConfig.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/spring/JmsConfig.java
@@ -141,8 +141,12 @@ public class JmsConfig {
             URI depositUri = parseResourceUri(mc, jsonParser);
             depositConsumer.accept(passClient.readResource(depositUri, Deposit.class));
         } catch (Exception e) {
-            LOG.error("Error parsing deposit URI from JMS message: {}\nPayload (if available): '{}'",
-                    e.getMessage(), mc.message().getPayload(), e);
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Error processing a JMS message for a 'Deposit' resource {}: {}\nPayload (if available): '{}'",
+                        mc.id(), e.getMessage(), mc.message().getPayload(), e);
+            } else {
+                LOG.error("Error processing a JMS message for a 'Deposit' resource {}: {}", mc.id(), e.getMessage(), e);
+            }
         } finally {
             ackMessage(mc);
         }

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/policy/FedoraMessagePolicy.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/policy/FedoraMessagePolicy.java
@@ -49,8 +49,9 @@ public abstract class FedoraMessagePolicy implements JmsMessagePolicy {
                 isMessageA(ret.EVENT_TYPE, ret.RESOURCE_TYPE, messageContext));
 
         if (!result) {
-            LOG.trace(">>>> Dropping message, it did not match any of the acceptable " +
+            LOG.trace(">>>> Dropping message {}, it did not match any of the acceptable " +
                             "FedoraResourceEventTypes {}: was {}",
+                    messageContext.id(),
                     acceptableFedoraResourceEventTypes().stream().map(Objects::toString).collect(joining(",")),
                     format(FedoraResourceEventType.FMT, messageContext.resourceType(), messageContext.eventType()));
             return false;

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositTaskHelper.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositTaskHelper.java
@@ -199,10 +199,9 @@ public class DepositTaskHelper {
                 },
 
                 /*
-                 * Postconditions: none to satisfy.  The completion of the critical path without an exception is
-                 *                 considered success.
+                 * Postconditions: the repoCopy returned from the critical section must not be null.
                  */
-                (criDeposit, criRepoCopy) -> true,
+                (criDeposit, criRepoCopy) -> criRepoCopy != null,
 
                 (criDeposit) -> {
                     AtomicReference<Deposit.DepositStatus> status = new AtomicReference<>();
@@ -216,6 +215,7 @@ public class DepositTaskHelper {
                         if (!repoConfig.isPresent()) {
                             LOG.error("Unable to resolve Repository Configuration for Repository {} ({})",
                                     repo.getName(), repo.getId());
+                            return null;
                         }
 
                         repoConfig.ifPresent(config -> {

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositUtil.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositUtil.java
@@ -203,6 +203,7 @@ public class DepositUtil {
      */
     public static void ackMessage(MessageContext mc) {
         try {
+            LOG.trace("Acking JMS message {}", mc.id());
             mc.jmsMessage().acknowledge();
         } catch (JMSException e) {
             LOG.error("Error acknowledging message (ack mode: {}): {} {}", mc.ackMode(), mc.dateTime(), mc.id(), e);

--- a/deposit-messaging/src/main/resources/logback.xml
+++ b/deposit-messaging/src/main/resources/logback.xml
@@ -31,7 +31,7 @@
   <logger name="org.dataconservancy" additivity="false" level="${org.dataconservancy.nihms.level:-DEBUG}">
     <appender-ref ref="STDERR"/>
   </logger>
-  <logger name="org.dataconservancy.pass.deposit" additivity="false" level="${org.dataconservancy.pass.deposit.level:-TRACE}">
+  <logger name="org.dataconservancy.pass.deposit" additivity="false" level="${org.dataconservancy.pass.deposit.level:-DEBUG}">
     <appender-ref ref="STDERR"/>
   </logger>
   <logger name="org.dataconservancy.pass.client" additivity="false" level="${org.dataconservancy.pass.client.level:-WARN}">


### PR DESCRIPTION
Adds new `RemedialDepositException`.  Can be thrown when failing deposit may be remediated by fixing the runtime configuration of Deposit Services.  When a `RemedialDepositException` is thrown, the associated `Deposit` should _not_ be be updated to a _terminal_ state.  Fixing the underlying cause of the exception (by, e.g. correcting the runtime configuration) and re-starting Deposit Services should fix the error and allow for the deposit to be re-tried successfully.