### PR TITLE
Filesystem transport module.

### DIFF
--- a/deposit-messaging/pom.xml
+++ b/deposit-messaging/pom.xml
@@ -224,6 +224,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.dataconservancy.pass.deposit</groupId>
+            <artifactId>filesystem-transport</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/repository/FilesystemBinding.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/repository/FilesystemBinding.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging.config.repository;
+
+import org.dataconservancy.pass.deposit.transport.Transport;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.dataconservancy.pass.deposit.transport.Transport.TRANSPORT_AUTHMODE;
+import static org.dataconservancy.pass.deposit.transport.Transport.TRANSPORT_PROTOCOL;
+import static org.dataconservancy.pass.deposit.transport.fs.FilesystemTransportHints.BASEDIR;
+import static org.dataconservancy.pass.deposit.transport.fs.FilesystemTransportHints.CREATE_IF_MISSING;
+import static org.dataconservancy.pass.deposit.transport.fs.FilesystemTransportHints.OVERWRITE;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class FilesystemBinding extends ProtocolBinding {
+
+    static final String PROTO = "filesystem";
+
+    private String baseDir;
+
+    private String overwrite;
+
+    private String createIfMissing;
+
+    public FilesystemBinding() {
+        setProtocol(PROTO);
+    }
+
+    @Override
+    public Map<String, String> asPropertiesMap() {
+        Map<String, String> transportProperties = new HashMap<>();
+
+        transportProperties.put(TRANSPORT_AUTHMODE, Transport.AUTHMODE.implicit.name());
+        transportProperties.put(TRANSPORT_PROTOCOL, Transport.PROTOCOL.filesystem.name());
+        transportProperties.put(BASEDIR, baseDir);
+        transportProperties.put(OVERWRITE, overwrite);
+        transportProperties.put(CREATE_IF_MISSING, createIfMissing);
+
+        return transportProperties;
+    }
+
+    public String getBaseDir() {
+        return baseDir;
+    }
+
+    public void setBaseDir(String baseDir) {
+        this.baseDir = baseDir;
+    }
+
+    public String getOverwrite() {
+        return overwrite;
+    }
+
+    public void setOverwrite(String overwrite) {
+        this.overwrite = overwrite;
+    }
+
+    public String getCreateIfMissing() {
+        return createIfMissing;
+    }
+
+    public void setCreateIfMissing(String createIfMissing) {
+        this.createIfMissing = createIfMissing;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        if (!super.equals(o))
+            return false;
+        FilesystemBinding that = (FilesystemBinding) o;
+        return Objects.equals(baseDir, that.baseDir) &&
+                Objects.equals(overwrite, that.overwrite) &&
+                Objects.equals(createIfMissing, that.createIfMissing);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), baseDir, overwrite, createIfMissing);
+    }
+
+    @Override
+    public String toString() {
+        return "FilesystemBinding{" + "baseDir='" + baseDir + '\'' + ", overwrite='" + overwrite + '\'' + ", " +
+                "createIfMissing='" + createIfMissing + '\'' + "} " + super.toString();
+    }
+}

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/repository/ProtocolBinding.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/repository/ProtocolBinding.java
@@ -21,15 +21,15 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import java.util.Map;
-import java.util.Objects;
 
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
         include = JsonTypeInfo.As.PROPERTY,
         property = "protocol")
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = FtpBinding.class, name = "ftp"),
-        @JsonSubTypes.Type(value = SwordV2Binding.class, name = "SWORDv2")
+        @JsonSubTypes.Type(value = FtpBinding.class, name = FtpBinding.PROTO),
+        @JsonSubTypes.Type(value = SwordV2Binding.class, name = SwordV2Binding.PROTO),
+        @JsonSubTypes.Type(value = FilesystemBinding.class, name = FilesystemBinding.PROTO)
 })
 public abstract class ProtocolBinding {
 

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/spring/DepositConfig.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/spring/DepositConfig.java
@@ -21,36 +21,35 @@ import okhttp3.Request;
 import okhttp3.logging.HttpLoggingInterceptor;
 import org.apache.abdera.parser.Parser;
 import org.apache.abdera.parser.stax.FOMParserFactory;
+import org.dataconservancy.pass.client.PassClientDefault;
 import org.dataconservancy.pass.client.SubmissionStatusService;
+import org.dataconservancy.pass.client.adapter.PassJsonAdapterBasic;
 import org.dataconservancy.pass.deposit.assembler.Assembler;
 import org.dataconservancy.pass.deposit.assembler.assembler.nihmsnative.NihmsAssembler;
 import org.dataconservancy.pass.deposit.assembler.assembler.nihmsnative.NihmsPackageProvider;
 import org.dataconservancy.pass.deposit.assembler.dspace.mets.DspaceMetadataDomWriterFactory;
+import org.dataconservancy.pass.deposit.assembler.dspace.mets.DspaceMetsAssembler;
 import org.dataconservancy.pass.deposit.assembler.dspace.mets.DspaceMetsPackageProvider;
 import org.dataconservancy.pass.deposit.assembler.shared.ExceptionHandlingThreadPoolExecutor;
-import org.dataconservancy.pass.deposit.assembler.shared.PackageProvider;
 import org.dataconservancy.pass.deposit.builder.fs.FcrepoModelBuilder;
 import org.dataconservancy.pass.deposit.builder.fs.FilesystemModelBuilder;
-import org.dataconservancy.pass.deposit.messaging.config.repository.Repositories;
-import org.dataconservancy.pass.deposit.messaging.config.repository.SwordV2Binding;
-import org.dataconservancy.pass.deposit.messaging.status.DepositStatusProcessor;
-import org.dataconservancy.pass.deposit.messaging.status.DepositStatusResolver;
-import org.dataconservancy.pass.deposit.transport.Transport;
-import org.dataconservancy.pass.deposit.transport.ftp.FtpTransport;
-import org.dataconservancy.pass.client.PassClientDefault;
-import org.dataconservancy.pass.client.adapter.PassJsonAdapterBasic;
-import org.dataconservancy.pass.deposit.assembler.dspace.mets.DspaceMetsAssembler;
 import org.dataconservancy.pass.deposit.messaging.DepositServiceErrorHandler;
 import org.dataconservancy.pass.deposit.messaging.DepositServiceRuntimeException;
+import org.dataconservancy.pass.deposit.messaging.config.repository.Repositories;
 import org.dataconservancy.pass.deposit.messaging.model.InMemoryMapRegistry;
 import org.dataconservancy.pass.deposit.messaging.model.Packager;
 import org.dataconservancy.pass.deposit.messaging.model.Registry;
 import org.dataconservancy.pass.deposit.messaging.policy.DirtyDepositPolicy;
 import org.dataconservancy.pass.deposit.messaging.service.DepositTask;
 import org.dataconservancy.pass.deposit.messaging.status.DefaultDepositStatusProcessor;
-import org.dataconservancy.pass.support.messaging.cri.CriticalRepositoryInteraction;
+import org.dataconservancy.pass.deposit.messaging.status.DepositStatusProcessor;
+import org.dataconservancy.pass.deposit.messaging.status.DepositStatusResolver;
 import org.dataconservancy.pass.deposit.messaging.support.swordv2.AtomFeedStatusResolver;
+import org.dataconservancy.pass.deposit.transport.Transport;
+import org.dataconservancy.pass.deposit.transport.fs.FilesystemTransport;
+import org.dataconservancy.pass.deposit.transport.ftp.FtpTransport;
 import org.dataconservancy.pass.deposit.transport.sword2.Sword2Transport;
+import org.dataconservancy.pass.support.messaging.cri.CriticalRepositoryInteraction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -275,11 +274,14 @@ public class DepositConfig {
     // TODO: discover Transports on the classpath
     @SuppressWarnings("SpringJavaAutowiringInspection")
     @Bean
-    public Map<String, Transport> transports(Sword2Transport sword2Transport, FtpTransport ftpTransport) {
+    public Map<String, Transport> transports(Sword2Transport sword2Transport,
+                                             FtpTransport ftpTransport,
+                                             FilesystemTransport fsTransport) {
         return new HashMap<String, Transport>() {
             {
                 put(Sword2Transport.PROTOCOL.SWORDv2.name(), sword2Transport);
                 put(FtpTransport.PROTOCOL.ftp.name(), ftpTransport);
+                put(Transport.PROTOCOL.filesystem.name(), fsTransport);
             }
         };
     }

--- a/filesystem-transport/pom.xml
+++ b/filesystem-transport/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Johns Hopkins University
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.dataconservancy.pass.deposit</groupId>
+        <artifactId>deposit-parent</artifactId>
+        <version>0.2.0-3.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>filesystem-transport</artifactId>
+    <name>File System Transport</name>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.dataconservancy.pass.deposit</groupId>
+            <artifactId>transport-api</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/filesystem-transport/src/main/java/org/dataconservancy/pass/deposit/transport/fs/FilesystemTransport.java
+++ b/filesystem-transport/src/main/java/org/dataconservancy/pass/deposit/transport/fs/FilesystemTransport.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.transport.fs;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.dataconservancy.pass.deposit.assembler.PackageStream;
+import org.dataconservancy.pass.deposit.transport.Transport;
+import org.dataconservancy.pass.deposit.transport.TransportResponse;
+import org.dataconservancy.pass.deposit.transport.TransportSession;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.dataconservancy.pass.deposit.transport.fs.FilesystemTransportHints.BASEDIR;
+import static org.dataconservancy.pass.deposit.transport.fs.FilesystemTransportHints.CREATE_IF_MISSING;
+import static org.dataconservancy.pass.deposit.transport.fs.FilesystemTransportHints.OVERWRITE;
+
+/**
+ * Writes {@link PackageStream}s to a directory on the filesystem.
+ * Hints accepted by this transport are:
+ * <dl>
+ *  <dt>baseDir</dt>
+ *  <dd>the absolute path to a directory on the filesystem for writing packages</dd>
+ *  <dt>createIfMissing</dt>
+ *  <dd>create the baseDir if it doesn't exist</dd>
+ *  <dt>overwrite</dt>
+ *  <dd>overwrite existing packages</dd>
+ * </dl>
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+@Component
+public class FilesystemTransport implements Transport {
+
+    private File baseDir;
+
+    private boolean createIfMissing;
+
+    private boolean overwrite;
+
+    @Override
+    public TransportSession open(Map<String, String> hints) {
+        baseDir = new File(hints.get(BASEDIR));
+        createIfMissing = Boolean.parseBoolean(hints.getOrDefault(CREATE_IF_MISSING, "true"));
+        overwrite = Boolean.parseBoolean(hints.getOrDefault(OVERWRITE, "false"));
+
+        if (!baseDir.exists()) {
+            if (createIfMissing) {
+                try {
+                    FileUtils.forceMkdir(baseDir);
+                } catch (IOException e) {
+                    throw new RuntimeException("Error creating base directory '" + baseDir + "' " + e.getMessage(), e);
+                }
+            } else {
+                throw new RuntimeException("Base directory '" + baseDir + "' does not exist.");
+            }
+        }
+
+        return new FilesystemTransportSession();
+    }
+
+    class FilesystemTransportSession implements TransportSession {
+
+        @Override
+        public TransportResponse send(PackageStream packageStream, Map<String, String> metadata) {
+            String filename = packageStream.metadata().name();
+            AtomicReference<Exception> transportException = new AtomicReference<>();
+            File outputFile = new File(baseDir, filename);
+
+            if (!outputFile.exists() || overwrite) {
+                try (InputStream in = packageStream.open(); OutputStream out = new FileOutputStream(outputFile)) {
+                    IOUtils.copy(in, out);
+                } catch (Exception e) {
+                    transportException.set(e);
+                }
+            } else {
+                transportException.set(new IOException("Output file '" + outputFile + "' already exists, and " +
+                        "'overwrite' flag is 'false'"));
+            }
+
+            return new TransportResponse() {
+                @Override
+                public boolean success() {
+                    return transportException.get() == null;
+                }
+
+                @Override
+                public Throwable error() {
+                    return transportException.get();
+                }
+            };
+        }
+
+        @Override
+        public boolean closed() {
+            return false;
+        }
+
+        @Override
+        public void close() throws Exception {
+            // no-op
+        }
+
+    }
+
+}

--- a/filesystem-transport/src/main/java/org/dataconservancy/pass/deposit/transport/fs/FilesystemTransportHints.java
+++ b/filesystem-transport/src/main/java/org/dataconservancy/pass/deposit/transport/fs/FilesystemTransportHints.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.transport.fs;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class FilesystemTransportHints {
+
+    public static final String CREATE_IF_MISSING = "createIfMissing";
+
+    public static final String OVERWRITE = "overwrite";
+
+    public static final String BASEDIR = "baseDir";
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
         <module>shared-assembler</module>
         <module>deposit-messaging</module>
         <module>shared-resources</module>
+        <module>filesystem-transport</module>
     </modules>
 
     <profiles>

--- a/transport-api/src/main/java/org/dataconservancy/pass/deposit/transport/Transport.java
+++ b/transport-api/src/main/java/org/dataconservancy/pass/deposit/transport/Transport.java
@@ -123,7 +123,8 @@ public interface Transport {
         http,
         https,
         ftp,
-        SWORDv2
+        SWORDv2,
+        filesystem
     }
 
     /**


### PR DESCRIPTION
Allows for packages to be streamed directly to the local file system.  Useful for integration tests that wish to verify the packages that are being written in response to a submission.

Supports resolution of #189 