### PR TITLE
Improvements to startup of Deposit Services

### DIFF
--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/DepositApp.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/DepositApp.java
@@ -53,6 +53,8 @@ public class DepositApp {
 
     private static final String GIT_BUILD_VERSION_KEY = "git.build.version";
 
+    private static final String GIT_BUILD_TIME = "git.build.time";
+
     private static final String GIT_COMMIT_HASH_KEY = "git.commit.id.abbrev";
 
     private static final String GIT_COMMIT_TIME_KEY = "git.commit.time";
@@ -80,8 +82,12 @@ public class DepositApp {
                 gitProperties.load(gitPropertiesResource.openStream());
                 boolean isDirty = Boolean.valueOf(gitProperties.getProperty(GIT_DIRTY_FLAG));
 
-                LOG.info(">>>> Starting DepositServices (version: {} branch: {} commit: {} commit date: {})",
-                        gitProperties.get(GIT_BUILD_VERSION_KEY), gitProperties.get(GIT_BRANCH), gitProperties.get(GIT_COMMIT_HASH_KEY), gitProperties.getProperty(GIT_COMMIT_TIME_KEY));
+            LOG.info(">>>> Starting DepositServices (version: {} branch: {} commit: {} commit date: {} build date: {})",
+                    gitProperties.get(GIT_BUILD_VERSION_KEY),
+                    gitProperties.get(GIT_BRANCH),
+                    gitProperties.get(GIT_COMMIT_HASH_KEY),
+                    gitProperties.get(GIT_COMMIT_TIME_KEY),
+                    gitProperties.get(GIT_BUILD_TIME));
 
                 if (isDirty) {
                     LOG.warn(">>>> ** Deposit Services was compiled from a Git repository with uncommitted changes! **");

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/spring/JmsConfig.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/spring/JmsConfig.java
@@ -107,13 +107,14 @@ public class JmsConfig {
         }
 
         // Parse the identity of the Submission from the message
-
+        URI submissionUri = null;
         try {
-            URI submissionUri = parseResourceUri(mc, jsonParser);
+            submissionUri = parseResourceUri(mc, jsonParser);
             submissionConsumer.accept(passClient.readResource(submissionUri, Submission.class));
         } catch (Exception e) {
-            LOG.error("Error parsing submission URI from JMS message: {}\nPayload (if available): '{}'",
-                    e.getMessage(), mc.message().getPayload(), e);
+            LOG.warn("Failed to process Submission ({}) from JMS message: {}\nPayload (if available): '{}'",
+                    (submissionUri == null ? "<failed to parse Submission URI from JMS message>" : submissionUri),
+                            e.getMessage(), mc.message().getPayload(), e);
         } finally {
             ackMessage(mc);
         }


### PR DESCRIPTION
- Import cleanup and removal of unused methods
- Log the git build time on start
- Protect against NPEs
- Improved logging of the Packagers used
- Improve logginging in JmsConfig when a Submission fails

Protect against NPEs when a configuration does not have a "deposit-processing" or "deposit-config" object.

Better reporting on Packager configuration during startup.

Add the build date to the Git information printed to the console on Deposit Services startup.

Improve logging when processing a JMS message fails.  There's a lot that happens when the submissionConsumer processes the Submission so the error message should be more generic.