### PR TITLE
Update the Submission.submissionStatus of candidate Submissions from a Quartz job

### DIFF
--- a/deposit-integration/pom.xml
+++ b/deposit-integration/pom.xml
@@ -293,6 +293,7 @@
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
+                    <autoCreateCustomNetworks>true</autoCreateCustomNetworks>
                     <images>
                         <image>
                             <alias>ftpserver</alias>
@@ -316,6 +317,10 @@
                                     <port>30009:30009</port>
                                     <port>30010:30010</port>
                                 </ports>
+                                <network>
+                                    <name>pass-net</name>
+                                    <alias>ftp</alias>
+                                </network>
                             </run>
                         </image>
                         <image>
@@ -332,6 +337,10 @@
                                 <env>
                                     <POSTGRES_DB_PORT>${postgres.port}</POSTGRES_DB_PORT>
                                 </env>
+                                <network>
+                                    <name>pass-net</name>
+                                    <alias>postgres</alias>
+                                </network>
                             </run>
                         </image>
                         <image>
@@ -346,14 +355,15 @@
                                 <ports>
                                     <port>${dspace.port}:${dspace.port}</port>
                                 </ports>
-                                <links>
-                                    <link>postgres</link>
-                                </links>
                                 <env>
                                     <DSPACE_HOST>${docker.host.address}</DSPACE_HOST>
                                     <DSPACE_PORT>${dspace.port}</DSPACE_PORT>
                                     <POSTGRES_DB_PORT>${postgres.port}</POSTGRES_DB_PORT>
                                 </env>
+                                <network>
+                                    <name>pass-net</name>
+                                    <alias>dspace</alias>
+                                </network>
                             </run>
                         </image>
                         <image>
@@ -380,6 +390,10 @@
                                     <FCREPO_LOG_LEVEL>DEBUG</FCREPO_LOG_LEVEL>
                                     <FCREPO_JMS_BASEURL>http://${fcrepo.server}:${fcrepo.http.port}/fcrepo/rest/</FCREPO_JMS_BASEURL>
                                 </env>
+                                <network>
+                                    <name>pass-net</name>
+                                    <alias>fcrepo</alias>
+                                </network>
                             </run>
                         </image>
                         <image>
@@ -401,6 +415,10 @@
                                     <bootstrap.memory_lock>true</bootstrap.memory_lock>
                                     <ES_JAVA_OPTS>-Xms512m -Xmx512m</ES_JAVA_OPTS>
                                 </env>
+                                <network>
+                                    <name>pass-net</name>
+                                    <alias>elasticsearch</alias>
+                                </network>
                             </run>
                         </image>
                         <image>
@@ -408,10 +426,6 @@
                             <name>${docker.indexer.version}</name>
                             <run>
                                 <skip>${indexer.skip}</skip>
-                                <links>
-                                    <link>elasticsearch</link>
-                                    <link>fcrepo</link>
-                                </links>
                                 <env>
                                     <PI_FEDORA_USER>${pass.fedora.user}</PI_FEDORA_USER>
                                     <PI_FEDORA_PASS>${pass.fedora.password}</PI_FEDORA_PASS>
@@ -423,6 +437,10 @@
                                     <PI_FEDORA_JMS_QUEUE>fedora</PI_FEDORA_JMS_QUEUE>
                                     <PI_TYPE_PREFIX>http://oapass.org/ns/pass#</PI_TYPE_PREFIX>
                                 </env>
+                                <network>
+                                    <name>pass-net</name>
+                                    <alias>indexer</alias>
+                                </network>
                             </run>
                         </image>
                     </images>

--- a/deposit-integration/pom.xml
+++ b/deposit-integration/pom.xml
@@ -34,6 +34,7 @@
         <postgres.skip>false</postgres.skip>
         <fcrepo.skip>false</fcrepo.skip>
         <fcrepo.server>${docker.host.address}</fcrepo.server>
+        <fcrepo.jms.baseurl>http://${fcrepo.server}:${fcrepo.http.port}/fcrepo/rest/</fcrepo.jms.baseurl>
         <pass.fedora.user>fedoraAdmin</pass.fedora.user>
         <pass.fedora.password>moo</pass.fedora.password>
         <pass.fedora.baseurl>http://${docker.host.address}:${fcrepo.http.port}/fcrepo/rest/</pass.fedora.baseurl>
@@ -388,7 +389,7 @@
                                     <FCREPO_STOMP_PORT>${fcrepo.stomp.port}</FCREPO_STOMP_PORT>
                                     <FCREPO_ACTIVEMQ_CONFIGURATION>classpath:/activemq-queue.xml</FCREPO_ACTIVEMQ_CONFIGURATION>
                                     <FCREPO_LOG_LEVEL>DEBUG</FCREPO_LOG_LEVEL>
-                                    <FCREPO_JMS_BASEURL>http://${fcrepo.server}:${fcrepo.http.port}/fcrepo/rest/</FCREPO_JMS_BASEURL>
+                                    <FCREPO_JMS_BASEURL>${fcrepo.jms.baseurl}</FCREPO_JMS_BASEURL>
                                 </env>
                                 <network>
                                     <name>pass-net</name>

--- a/deposit-integration/pom.xml
+++ b/deposit-integration/pom.xml
@@ -424,10 +424,14 @@
                         </image>
                         <image>
                             <alias>indexer</alias>
-                            <name>${docker.indexer.version}</name>
+                            <name>oapass/indexer-wrapped:latest</name>
+                            <build>
+                                <dockerFile>${project.build.testOutputDirectory}/docker/Dockerfile-indexer</dockerFile>
+                            </build>
                             <run>
                                 <skip>${indexer.skip}</skip>
                                 <env>
+                                    <TRAVIS>${env.TRAVIS}</TRAVIS>
                                     <PI_FEDORA_USER>${pass.fedora.user}</PI_FEDORA_USER>
                                     <PI_FEDORA_PASS>${pass.fedora.password}</PI_FEDORA_PASS>
                                     <PI_FEDORA_INTERNAL_BASE>http://fcrepo:${fcrepo.http.port}/fcrepo/rest/</PI_FEDORA_INTERNAL_BASE>

--- a/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/messaging/service/DepositProcessorIT.java
+++ b/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/messaging/service/DepositProcessorIT.java
@@ -15,15 +15,6 @@
  */
 package org.dataconservancy.pass.deposit.messaging.service;
 
-import java.io.InputStream;
-
-import java.net.URI;
-
-import java.util.Collection;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import org.dataconservancy.deposit.util.async.Condition;
 import org.dataconservancy.pass.deposit.messaging.config.spring.DepositConfig;
 import org.dataconservancy.pass.deposit.messaging.config.spring.JmsConfig;
@@ -33,12 +24,17 @@ import org.dataconservancy.pass.model.RepositoryCopy;
 import org.dataconservancy.pass.model.Submission;
 import org.dataconservancy.pass.model.Submission.AggregatedDepositStatus;
 import org.dataconservancy.pass.model.Submission.SubmissionStatus;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-
 import submissions.SubmissionResourceUtil;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Collection;
 
 import static org.dataconservancy.pass.deposit.messaging.service.SubmissionTestUtil.getDepositUris;
 import static org.dataconservancy.pass.deposit.messaging.service.SubmissionTestUtil.getFileUris;

--- a/deposit-integration/src/test/resources/docker/Dockerfile-indexer
+++ b/deposit-integration/src/test/resources/docker/Dockerfile-indexer
@@ -1,0 +1,28 @@
+FROM ${docker.indexer.version}
+
+#
+# In the Deposit Services integration environment on Travis, JMS messages contain URIs to Fedora resources in the
+# form: http://localhost:44453/fcrepo/rest/....
+#
+# This is governed by the FCREPO_JMS_BASEURL.  The integration tests running *outside* of Docker need to be able to
+# resolve these resources, and the indexer running *inside* Docker also need to resolve these resources.  Resolving
+# localhost from outside of Docker works, but resolving localhost from within the indexer container does not work:
+# localhost needs to resolve to the Fedora repository, fcrepo.
+#
+# This Docker container munges /etc/hosts for the production index container, so that lookups for localhost will
+# resolve to the IP for the fcrepo machine.
+#
+# For whatever reason, this hack cannot take place in the docker-maven-plugin using <networks> or <links> (at least, I
+# couldn't get it to work).
+#
+
+CMD echo "Munging /etc/hosts for the Travis build..." ; \
+      apk add --no-cache bind-tools ; \
+      FCREPO_IP=`dig fcrepo +short` ; \
+      echo "Discovered FCREPO_IP: ${FCREPO_IP}" ; \
+      sed -e '/127.0.0.1/d' < /etc/hosts > /tmp/moo ; \
+      sed -e '/localhost/d' < /tmp/moo > /etc/hosts ; \
+      echo "${FCREPO_IP}  localhost" >> /etc/hosts ; \
+      cat /etc/hosts ; \
+      rm -rf /var/cache/apk/ ; \
+    ./wait_and_start.sh pass-indexer-cli-${PI_VERSION}-SNAPSHOT-shaded.jar ;

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/quartz/QuartzConfig.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/quartz/QuartzConfig.java
@@ -18,6 +18,7 @@ package org.dataconservancy.pass.deposit.messaging.config.quartz;
 
 import org.dataconservancy.pass.deposit.messaging.DepositServiceErrorHandler;
 import org.dataconservancy.pass.deposit.messaging.support.quartz.DepositUpdaterJob;
+import org.dataconservancy.pass.deposit.messaging.support.quartz.SubmissionStatusUpdaterJob;
 import org.quartz.JobBuilder;
 import org.quartz.JobDetail;
 import org.quartz.SimpleTrigger;
@@ -50,6 +51,10 @@ public class QuartzConfig {
 
     private final String DEPOSIT_UPDATER_JOB = "depositUpdater";
 
+    private final String SUBMISSION_STATUS_JOB_GROUP = "submissionStatusJobs";
+
+    private final String SUBMISSION_UPDATER_JOB = "submissionStatusUpdater";
+
     @Value("${pass.deposit.jobs.default-interval-ms}")
     private long defaultJobInterval;
 
@@ -73,6 +78,25 @@ public class QuartzConfig {
                         .withIntervalInMilliseconds(defaultJobInterval)
                         .repeatForever())
                 .forJob(depositUpdaterJobDetail)
+                .build();
+    }
+
+    @Bean
+    public JobDetail submissionStatusUpdaterJobDetail() {
+        return JobBuilder.newJob(SubmissionStatusUpdaterJob.class)
+                .withIdentity(SUBMISSION_UPDATER_JOB, SUBMISSION_STATUS_JOB_GROUP)
+                .storeDurably()
+                .build();
+    }
+
+    @Bean
+    public SimpleTrigger submissionStatusUpdateTrigger(JobDetail submissionStatusUpdaterJobDetail) {
+        return TriggerBuilder.newTrigger()
+                .forJob(SUBMISSION_UPDATER_JOB, SUBMISSION_STATUS_JOB_GROUP)
+                .withSchedule(simpleSchedule()
+                        .withIntervalInMilliseconds(defaultJobInterval)
+                        .repeatForever())
+                .forJob(submissionStatusUpdaterJobDetail)
                 .build();
     }
 

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionStatusUpdater.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionStatusUpdater.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2019 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging.service;
+
+import org.dataconservancy.pass.client.PassClient;
+import org.dataconservancy.pass.client.SubmissionStatusService;
+import org.dataconservancy.pass.model.Submission;
+import org.dataconservancy.pass.support.messaging.cri.CriticalRepositoryInteraction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Recalculates the {@code Submission.submissionStatus} for a collection of Submission URIs.
+ * <p>
+ * The calculation of {@code Submission.submissionStatus} is handled by the {@link SubmissionStatusService}.  Any
+ * {@code Submission} with a {@code submissionStatus} that is <em>not </em> {@code COMPLETE} or {@code CANCELLED} make
+ * up the collection of Submission URIs to be processed.
+ * </p>
+ * <p>
+ * The criteria for determining which Submissions need to have their {@code submissionStatus} updated is hard-coded and
+ * limited in part by the {@link PassClient}.  An alternate approach would be to configure a resource with a query in
+ * the ElasticSearch DSL, and communicate directly with the ElasticSearch Query API.  This allows more surgical
+ * retrieval of candidate Submissions, and externalizes the query from compiled code.
+ * </p>
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+@Component
+public class SubmissionStatusUpdater {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SubmissionStatusUpdater.class);
+
+    private SubmissionStatusService statusService;
+
+    private PassClient passClient;
+
+    private CriticalRepositoryInteraction cri;
+
+    @Autowired
+    public SubmissionStatusUpdater(SubmissionStatusService statusService, PassClient passClient,
+                                   CriticalRepositoryInteraction cri) {
+        this.statusService = statusService;
+        this.passClient = passClient;
+        this.cri = cri;
+    }
+
+    /**
+     * Determines the Submissions to be updated, and updates the status of each in turn.
+     */
+    public void doUpdate() {
+        doUpdate(toUpdate(passClient));
+    }
+
+    /**
+     * Accepts a collection of Submissions to be updated, and updates the status of each in turn.
+     *
+     * @param submissionUris a collection of Submission URIs to be updated
+     */
+    public void doUpdate(Collection<URI> submissionUris) {
+        if (submissionUris == null || submissionUris.size() == 0) {
+            LOG.trace("No submissions to update.");
+            return;
+        } else {
+            LOG.trace("Updating the Submission.submissionStatus of {} Submission{}", submissionUris.size(),
+                    submissionUris.size() > 1 ? "s" : "");
+        }
+
+        submissionUris.forEach(uri -> {
+            try {
+                LOG.debug("Updating Submission.submissionStatus for {}", uri);
+                cri.performCritical(uri, Submission.class, CriFunc.preCondition, CriFunc.postCondition,
+                        CriFunc.critical(statusService));
+            } catch (Exception e) {
+                LOG.debug("Unable to update the 'submissionStatus' of {}", uri, e);
+            }
+        });
+    }
+
+    /**
+     * Returns all Submissions that have any Submission.SubmissionStatus <em>except</em> SubmissionStatus.COMPLETE or
+     * SubmissionStatus.CANCELLED.
+     *
+     * @param passClient the client used to communicate with the index
+     * @return the URIs of Submissions that may need their SubmissionStatus updated
+     */
+    private static Collection<URI> toUpdate(PassClient passClient) {
+        return Stream.of(Submission.SubmissionStatus.values())
+                .filter(status -> status != Submission.SubmissionStatus.COMPLETE)
+                .filter(status -> status != Submission.SubmissionStatus.CANCELLED)
+                .map(status -> status.name().toLowerCase())
+                .map(status -> passClient.findAllByAttribute(Submission.class, "submissionStatus", status))
+                .flatMap(Collection::stream)
+                .peek(uri -> LOG.debug("Collecting Submission URI {}", uri))
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Convenience class encapsulating the pre- and post-conditions for executing the critical function over the
+     * Submission.
+     */
+    static class CriFunc {
+
+        /**
+         * Verifies the expected state of the Submission before updating the Submission.submissionStatus:
+         * <ul>
+         *     <li>Submission.submitted must be 'true'</li>
+         *     <li>Submission.submissionStatus must not be 'COMPLETE'</li>
+         *     <li>Submission.submissionStatus must not be 'CANCELLED'</li>
+         * </ul>
+         */
+        static Predicate<Submission> preCondition = (submission) -> submission.getSubmissionStatus() != null &&
+                submission.getSubmissionStatus() != Submission.SubmissionStatus.COMPLETE &&
+                submission.getSubmissionStatus() != Submission.SubmissionStatus.CANCELLED &&
+                submission.getSubmitted() != null &&
+                submission.getSubmitted() == Boolean.TRUE;
+
+        /**
+         * Verifies the expected state of the Submission after updating Submission.submissionStatus:
+         * <ul>
+         *     <li>Submission.submissionStatus must not be 'null'</li>
+         *     <li>Submission.submitted must be 'true'</li>
+         * </ul>
+         */
+        static Predicate<Submission> postCondition = (submission -> submission.getSubmissionStatus() != null &&
+                submission.getSubmitted() != null
+                && submission.getSubmitted() == Boolean.TRUE);
+
+        /**
+         * Critical section calculates the Submission.submissionStatus, which may or may not be different from the
+         * initial Submission.submissionStatus.
+         */
+        static Function<Submission, Submission> critical(SubmissionStatusService statusService) {
+            return (submission -> {
+                submission.setSubmissionStatus(statusService.calculateSubmissionStatus(submission));
+                return submission;
+            });
+        }
+    }
+
+}

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/quartz/SubmissionStatusUpdaterJob.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/quartz/SubmissionStatusUpdaterJob.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging.support.quartz;
+
+import org.dataconservancy.pass.deposit.messaging.service.SubmissionStatusUpdater;
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+@Component
+@DisallowConcurrentExecution
+public class SubmissionStatusUpdaterJob implements Job {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SubmissionStatusUpdaterJob.class);
+
+    private SubmissionStatusUpdater updater;
+
+    @Autowired
+    public SubmissionStatusUpdaterJob(SubmissionStatusUpdater updater) {
+        this.updater = updater;
+    }
+
+    @Override
+    public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+        LOG.trace("Starting {}", this.getClass().getSimpleName());
+        updater.doUpdate();
+        LOG.trace("Finished {}", this.getClass().getSimpleName());
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -155,13 +155,13 @@
         <sword2-client.version>0.9.3</sword2-client.version>
         <mets-api.version>1.3.0</mets-api.version>
         <tika.version>1.17</tika.version>
-        <pass-client.version>0.5.0</pass-client.version>
+        <pass-client.version>0.5.2</pass-client.version>
         <fast-classpath-scanner.version>3.1.5</fast-classpath-scanner.version>
         <jackson.version>2.9.6</jackson.version>
         <messaging-support.version>0.1.2-3.2-SNAPSHOT</messaging-support.version>
 
         <docker.fcrepo.version>oapass/fcrepo:4.7.5-3.2-2</docker.fcrepo.version>
-        <docker.indexer.version>oapass/indexer:0.0.17-3.2-SNAPSHOT</docker.indexer.version>
+        <docker.indexer.version>oapass/indexer@sha256:b572bb48814fb1624a29556fd648de7b4f432c9f65f904d609efcf7f8ac36948</docker.indexer.version>
         <docker.elasticsearch.version>docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.3</docker.elasticsearch.version>
 
         <!-- TODO properly tag these images -->


### PR DESCRIPTION
Moves the logic out of the `DepositProcessor` to a dedicated Quartz job.

- Valid candidate Submissions are those with an existing 'submissionStatus' not equal to COMPLETE or CANCELLED
- Upgrade to version 5.0.2 (from 5.0.0) of the PassClient, which contains bug fixes to the SubmissionStatusService

Resolves https://github.com/OA-PASS/general-issues/issues/117