### PR TITLE
Prevent Quartz jobs from one ApplicationContext acting on state in another ApplicationContext.

### DIFF
--- a/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/support/QuartzTestExecutionListener.java
+++ b/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/support/QuartzTestExecutionListener.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2019 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.support;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+import org.springframework.scheduling.quartz.SchedulerFactoryBean;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+
+import static java.lang.Integer.toHexString;
+import static java.lang.System.identityHashCode;
+
+/**
+ * Conditionally disables Quartz jobs prior to running an integration test, and unconditionally stops Quartz jobs after
+ * running an integration test.
+ * <p>
+ * If the property {@code pass.deposit.jobs.disabled} is present in the Spring {@code Environment} with a value of
+ * {@code true}, and the {@code SchedulerFactoryBean} is running, the scheduler will be stopped in {@link
+ * #beforeTestClass(TestContext)}.
+ * </p>
+ * <p>
+ * At the end of every integration test, the Quartz {@code SchedulerFactoryBean} is stopped to prevent jobs from one
+ * Application Context affecting the state of tests executed in a different Application Context.
+ * </p>
+ * <h3>Background</h3>
+ * Spring will construct, and cache, multiple Application Contexts when executing integration tests.  The problem is
+ * that background threads, including Quartz jobs, launched by one Application Context live on after an integration
+ * tests for that context complete.  Therefore, Quartz Jobs launched by Application Context "A" may act on the state of
+ * Application Context "B", and potentially alter test outcome.
+ * <p>
+ * This test execution listener stops the Quartz jobs launched by its application at the {@link
+ * #afterTestClass(TestContext) end} of each test.  If the Application Context is re-used (i.e. pulled from the cache
+ * of Application Contexts and used for another test class), this test execution listener will start the Quartz jobs as
+ * long as {@code pass.deposit.jobs.disabled} is not equal to {@code true}.
+ * </p>
+ * <p>
+ * This {@code TestExecutionListener} is automatically configured on tests annotated with {@code SpringBootTest}
+ * because it is automatically configured in {@code META-INF/spring.factories}; that is, it is considered a
+ * <em>default</em> {@code TestExecutionListener}.
+ * </p>
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class QuartzTestExecutionListener extends AbstractTestExecutionListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(QuartzTestExecutionListener.class);
+
+    private static final String DISABLED = "pass.deposit.jobs.disabled";
+
+    @Override
+    public void beforeTestClass(TestContext testContext) throws Exception {
+        super.beforeTestClass(testContext);
+
+        ApplicationContext appCtx = testContext.getApplicationContext();
+        Environment env = appCtx.getEnvironment();
+        SchedulerFactoryBean quartzScheduler = getSchedulerFactoryBean(appCtx);
+
+        if (quartzScheduler == null) {
+            return;
+        }
+
+        boolean isDisabled = Boolean.parseBoolean(env.getProperty(DISABLED));
+        boolean isEnabled = !isDisabled;
+
+        if (!quartzScheduler.isRunning()) {
+            if (isEnabled) {
+                LOG.debug("Starting {} ({}): the scheduler is not running, and it is enabled ({}={})",
+                        classString(quartzScheduler), classString(appCtx), DISABLED, env.getProperty(DISABLED));
+                    quartzScheduler.start();
+            } else {
+                LOG.debug("{} ({}) taking no action: the scheduler is not running, and it is disabled ({}={})",
+                        classString(quartzScheduler), classString(appCtx), DISABLED, env.getProperty(DISABLED));
+            }
+
+            return;
+        }
+
+        if (isDisabled) {
+            LOG.debug("Stopping {} ({}): the scheduler is running, and it is disabled ({}={})",
+                    classString(quartzScheduler), classString(appCtx), DISABLED, env.getProperty(DISABLED));
+            quartzScheduler.stop();
+        } else {
+            LOG.debug("{} ({}) taking no action: the scheduler is running, and it is enabled ({}={})",
+                    classString(quartzScheduler), classString(appCtx), DISABLED, env.getProperty(DISABLED));
+        }
+    }
+
+    @Override
+    public void afterTestClass(TestContext testContext) throws Exception {
+        super.afterTestClass(testContext);
+
+        ApplicationContext appCtx = testContext.getApplicationContext();
+        SchedulerFactoryBean quartzScheduler = getSchedulerFactoryBean(appCtx);
+
+        if (quartzScheduler == null) {
+            return;
+        }
+
+        if (quartzScheduler.isRunning()) {
+            LOG.debug("Stopping the {} ({}) so the running jobs do not act on future tests.",
+                    classString(quartzScheduler), classString(appCtx));
+            quartzScheduler.stop();
+        }
+    }
+
+    private SchedulerFactoryBean getSchedulerFactoryBean(ApplicationContext appCtx) {
+        SchedulerFactoryBean quartzScheduler = null;
+        try {
+            quartzScheduler = appCtx.getBean(SchedulerFactoryBean.class);
+        } catch (BeansException e) {
+            LOG.debug("{} will not run: {}", classString(this), e.getMessage(), e);
+        }
+
+        return quartzScheduler;
+    }
+
+    private static String classString(Object o) {
+        return className(o) + "@" + hash(o);
+    }
+
+    private static String className(Object o) {
+        return o.getClass().getSimpleName();
+    }
+
+    private static String hash(Object o) {
+        return toHexString(identityHashCode(o));
+    }
+}

--- a/deposit-integration/src/test/resources/META-INF/spring.factories
+++ b/deposit-integration/src/test/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.test.context.TestExecutionListener=org.dataconservancy.pass.deposit.support.QuartzTestExecutionListener

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/quartz/QuartzConfig.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/quartz/QuartzConfig.java
@@ -61,6 +61,13 @@ public class QuartzConfig {
     @Value("${pass.deposit.jobs.concurrency}")
     private int jobWorkerConcurrency;
 
+    /**
+     * This property is set to <em>true</em> if we are to disable the Quartz scheduler.  If the property is missing, it
+     * will default to <em>false</em> (i.e. enable the scheduler).
+     */
+    @Value("${pass.deposit.jobs.disabled}")
+    private boolean disabled;
+
 
     @Bean
     public JobDetail depositUpdaterJobDetail() {
@@ -125,7 +132,13 @@ public class QuartzConfig {
 
     @Bean
     public SchedulerFactoryBeanCustomizer quartzCustomizer(ThreadPoolTaskExecutor quartzTaskExecutor) {
-        return (factoryBean) -> factoryBean.setTaskExecutor(quartzTaskExecutor);
+        return (factoryBean) -> {
+            factoryBean.setTaskExecutor(quartzTaskExecutor);
+            factoryBean.setAutoStartup(!disabled);
+            if (disabled) {
+                LOG.debug("Quartz SchedulerFactoryBean autoStartup is disabled!");
+            }
+        };
     }
 
 }

--- a/deposit-messaging/src/main/resources/application.properties
+++ b/deposit-messaging/src/main/resources/application.properties
@@ -37,6 +37,7 @@ pass.deposit.queue.deposit.name=deposit
 pass.deposit.queue.submission.name=submission
 # TODO probably should be configured on a repository-by-repository basis
 pass.deposit.transport.swordv2.sleep-time-ms=10000
+pass.deposit.jobs.disabled=false
 # By default run all jobs every 10 minutes
 pass.deposit.jobs.default-interval-ms=600000
 pass.deposit.jobs.concurrency=2


### PR DESCRIPTION
Conditionally disables Quartz jobs prior to running an integration test, and unconditionally stops Quartz jobs after running an integration test.

Spring will construct, and cache, multiple Application Contexts when executing integration tests.  The problem is that background threads, including Quartz jobs, launched by one Application Context live on after integration tests for that context complete.  Therefore, Quartz Jobs launched by Application Context "A" may act on the state of Application Context "B", and potentially alter test outcome.

This test execution listener stops the Quartz jobs launched by its application at the`afterTestClass(TestContext)` (end) of each test.  If the Application Context is re-used (i.e. pulled from the cache of Application Contexts and used for another test class), this test execution listener will start the Quartz jobs as long as `pass.deposit.jobs.disabled` is not equal to `true`.

This `TestExecutionListener` is automatically configured on tests annotated with `SpringBootTest`  because it is automatically configured in `META-INF/spring.factories`; that is, it is considered a _default_ `TestExecutionListener`.

Additionally, update the `QuartzConfig` to respect `pass.deposit.jobs.disabled`, and disable the auto-starting of Quartz if `pass.deposit.jobs.disabled` is `true`.

Supports resolution of #189 