### PR TITLE
Bump POM version to 1.0.0-3.4-SNAPSHOT

### DIFF
--- a/assembler-api/pom.xml
+++ b/assembler-api/pom.xml
@@ -14,15 +14,14 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.dataconservancy.pass.deposit</groupId>
         <artifactId>deposit-parent</artifactId>
-        <version>0.2.0-3.2-SNAPSHOT</version>
+        <version>1.0.0-3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>assembler-api</artifactId>

--- a/builder-api/pom.xml
+++ b/builder-api/pom.xml
@@ -14,15 +14,14 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.dataconservancy.pass.deposit</groupId>
         <artifactId>deposit-parent</artifactId>
-        <version>0.2.0-3.2-SNAPSHOT</version>
+        <version>1.0.0-3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>builder-api</artifactId>

--- a/deposit-integration/pom.xml
+++ b/deposit-integration/pom.xml
@@ -14,15 +14,14 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.dataconservancy.pass.deposit</groupId>
         <artifactId>deposit-parent</artifactId>
-        <version>0.2.0-3.2-SNAPSHOT</version>
+        <version>1.0.0-3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>deposit-integration</artifactId>

--- a/deposit-messaging/pom.xml
+++ b/deposit-messaging/pom.xml
@@ -14,15 +14,14 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.dataconservancy.pass.deposit</groupId>
         <artifactId>deposit-parent</artifactId>
-        <version>0.2.0-3.2-SNAPSHOT</version>
+        <version>1.0.0-3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>deposit-messaging</artifactId>

--- a/deposit-model/pom.xml
+++ b/deposit-model/pom.xml
@@ -14,15 +14,14 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.dataconservancy.pass.deposit</groupId>
         <artifactId>deposit-parent</artifactId>
-        <version>0.2.0-3.2-SNAPSHOT</version>
+        <version>1.0.0-3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>deposit-model</artifactId>

--- a/deposit-util/pom.xml
+++ b/deposit-util/pom.xml
@@ -14,15 +14,14 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.dataconservancy.pass.deposit</groupId>
         <artifactId>deposit-parent</artifactId>
-        <version>0.2.0-3.2-SNAPSHOT</version>
+        <version>1.0.0-3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>deposit-util</artifactId>

--- a/fedora-builder/pom.xml
+++ b/fedora-builder/pom.xml
@@ -14,15 +14,14 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.dataconservancy.pass.deposit</groupId>
         <artifactId>deposit-parent</artifactId>
-        <version>0.2.0-3.2-SNAPSHOT</version>
+        <version>1.0.0-3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>fedora-builder</artifactId>

--- a/filesystem-transport/pom.xml
+++ b/filesystem-transport/pom.xml
@@ -14,15 +14,14 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.dataconservancy.pass.deposit</groupId>
         <artifactId>deposit-parent</artifactId>
-        <version>0.2.0-3.2-SNAPSHOT</version>
+        <version>1.0.0-3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>filesystem-transport</artifactId>

--- a/ftp-transport/pom.xml
+++ b/ftp-transport/pom.xml
@@ -14,15 +14,14 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.dataconservancy.pass.deposit</groupId>
         <artifactId>deposit-parent</artifactId>
-        <version>0.2.0-3.2-SNAPSHOT</version>
+        <version>1.0.0-3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>ftp-transport</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,13 +14,12 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.dataconservancy.pass.deposit</groupId>
     <artifactId>deposit-parent</artifactId>
-    <version>0.2.0-3.2-SNAPSHOT</version>
+    <version>1.0.0-3.4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Deposit Services Parent Project</name>
     <description>Responsible for the transfer of custody to downstream repositories</description>

--- a/shared-assembler/pom.xml
+++ b/shared-assembler/pom.xml
@@ -14,15 +14,14 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.dataconservancy.pass.deposit</groupId>
         <artifactId>deposit-parent</artifactId>
-        <version>0.2.0-3.2-SNAPSHOT</version>
+        <version>1.0.0-3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>shared-assembler</artifactId>

--- a/shared-integration/pom.xml
+++ b/shared-integration/pom.xml
@@ -14,15 +14,14 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.dataconservancy.pass.deposit</groupId>
         <artifactId>deposit-parent</artifactId>
-        <version>0.2.0-3.2-SNAPSHOT</version>
+        <version>1.0.0-3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>shared-integration</artifactId>

--- a/shared-resources/pom.xml
+++ b/shared-resources/pom.xml
@@ -14,15 +14,14 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.dataconservancy.pass.deposit</groupId>
         <artifactId>deposit-parent</artifactId>
-        <version>0.2.0-3.2-SNAPSHOT</version>
+        <version>1.0.0-3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>shared-resources</artifactId>

--- a/sword2-transport/pom.xml
+++ b/sword2-transport/pom.xml
@@ -14,15 +14,14 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.dataconservancy.pass.deposit</groupId>
         <artifactId>deposit-parent</artifactId>
-        <version>0.2.0-3.2-SNAPSHOT</version>
+        <version>1.0.0-3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>sword2-transport</artifactId>

--- a/transport-api/pom.xml
+++ b/transport-api/pom.xml
@@ -14,15 +14,14 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.dataconservancy.pass.deposit</groupId>
         <artifactId>deposit-parent</artifactId>
-        <version>0.2.0-3.2-SNAPSHOT</version>
+        <version>1.0.0-3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>transport-api</artifactId>


### PR DESCRIPTION
Bump from 0.2.0-SNAPSHOT to 1.0.0-3.4-SNAPSHOT.

- 1.0.0 because this is the first release requiring package providers
- 3.4 because this release supports context version 3.4
- Docker image name has changed to oapass/deposit-services-core
