### PR TITLE
Provide support for BagIt

### DIFF
--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/repository/AssemblerOptions.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/repository/AssemblerOptions.java
@@ -15,6 +15,8 @@
  */
 package org.dataconservancy.pass.deposit.messaging.config.repository;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import org.dataconservancy.pass.deposit.assembler.PackageOptions.Archive;
 import org.dataconservancy.pass.deposit.assembler.PackageOptions.Checksum;
 import org.dataconservancy.pass.deposit.assembler.PackageOptions.Compression;
@@ -26,6 +28,25 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
+ * Represents the {@code options} provided to an Assembler, typically serialized from JSON.  This class encapsulates
+ * the {@code options} object in the example serialization below:
+ * <pre>
+ *     "BagIt": {
+ *     "assembler": {
+ *       "specification": "simple",
+ *       "beanName": "simpleAssembler",
+ *       "options": {
+ *         "archive": "ZIP",
+ *         "compression": "NONE",
+ *         "algorithms": [
+ *           "sha512",
+ *           "md5"
+ *         ],
+ *         "baginfo-template-resource": "/bag-info.hbm"
+ *       }
+ *     }
+ * </pre>
+ *
  * @author Elliot Metsger (emetsger@jhu.edu)
  */
 public class AssemblerOptions {
@@ -35,6 +56,13 @@ public class AssemblerOptions {
     private String archive;
 
     private List<String> algorithms;
+
+    /*
+     * Carries additional Assembler options that are not defined as fields on this class.  Allows for arbitrary content
+     * to be added to the Assembler configuration in {@code repositories.json} without causing errors in serialization,
+     * and without adding new fields and accessors to this class.
+     */
+    private Map<String, Object> optionsMap = new HashMap<>();
 
     public String getCompression() {
         return compression;
@@ -60,6 +88,74 @@ public class AssemblerOptions {
         this.algorithms = algorithms;
     }
 
+    /**
+     * Includes only those configuration keys that are not explicitly defined (i.e. lack accessor methods) in this
+     * AssemblerOptions.  Given the following Assembler configuration in {@code repositories.json}:
+     * <pre>
+     *     "BagIt": {
+     *     "assembler": {
+     *       "specification": "simple",
+     *       "beanName": "simpleAssembler",
+     *       "options": {
+     *         "archive": "ZIP",
+     *         "compression": "NONE",
+     *         "algorithms": [
+     *           "sha512",
+     *           "md5"
+     *         ],
+     *         "baginfo-template-resource": "/bag-info.hbm"
+     *       }
+     *     }
+     * </pre>
+     *
+     * The {@code Map} returned by this method will only contain {@code baginfo-template-resource}.  The other
+     * properties present in the {@code options} JSON object have defined accessors in AssemblerOptions, so they are not
+     * included in the returned {@code Map}.  If <em>every</em> key is desired, see {@link #asOptionsMap()}.
+     *
+     * @return every key and value in the {@code options} JSON object that lacks accessor methods
+     * @see #getOptionsMap()
+     * @see #getAlgorithms()
+     * @see #getArchive()
+     * @see #getCompression()
+     */
+    @JsonAnyGetter
+    public Map<String, Object> getOptionsMap() {
+        return optionsMap;
+    }
+
+    @JsonAnySetter
+    public void add(String key, Object value) {
+        optionsMap.put(key, value);
+    }
+
+    /**
+     * Includes every configuration key in this AssemblerOptions as a {@code Map}.  This method differs from {@link
+     * #getOptionsMap()} by including <em>every</em> configuration key in the returned {@code Map}, while {@link
+     * #getOptionsMap()} only includes "extra" options.  Given the following Assembler configuration in {@code
+     * repositories.json}
+     * <pre>
+     *     "BagIt": {
+     *     "assembler": {
+     *       "specification": "simple",
+     *       "beanName": "simpleAssembler",
+     *       "options": {
+     *         "archive": "ZIP",
+     *         "compression": "NONE",
+     *         "algorithms": [
+     *           "sha512",
+     *           "md5"
+     *         ],
+     *         "baginfo-template-resource": "/bag-info.hbm"
+     *       }
+     *     }
+     * </pre>
+     *
+     * The {@code Map} returned by this method will contain every key and value in the {@code options} JSON object,
+     * including {@code baginfo-template-resource}.
+     *
+     * @return every key and value in {@code options} JSON object as a {@code Map}
+     * @see #getOptionsMap()
+     */
     public Map<String, Object> asOptionsMap() {
         return new HashMap<String, Object>() {
             {
@@ -75,6 +171,7 @@ public class AssemblerOptions {
                                     .map(algo -> Checksum.OPTS.valueOf(algo.toUpperCase()))
                                     .collect(Collectors.toList()));
                 }
+                this.putAll(optionsMap);
             }
         };
     }

--- a/deposit-messaging/src/main/resources/repositories.json
+++ b/deposit-messaging/src/main/resources/repositories.json
@@ -44,5 +44,29 @@
         "overwrite": "true"
       }
     }
+  },
+
+  "BagIt": {
+    "assembler": {
+      "specification": "simple",
+      "beanName": "simpleAssembler",
+      "options": {
+        "archive": "ZIP",
+        "compression": "NONE",
+        "algorithms": [
+          "sha512",
+          "md5"
+        ],
+        "baginfo-template-resource": "/bag-info.hbm"
+      }
+    },
+    "transport-config": {
+      "protocol-binding": {
+        "protocol": "filesystem",
+        "baseDir": "target/packages",
+        "createIfMissing": "true",
+        "overwrite": "true"
+      }
+    }
   }
 }

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/config/repository/AssemblerOptionsMappingTest.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/config/repository/AssemblerOptionsMappingTest.java
@@ -19,7 +19,9 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.*;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Elliot Metsger (emetsger@jhu.edu)
@@ -36,6 +38,19 @@ public class AssemblerOptionsMappingTest extends AbstractJacksonMappingTest {
             "        ]\n" +
             "}";
 
+    private static final String OPTIONS_CONFIG_ADDITIONAL_VALUES = "" +
+            "{\n" +
+            "        \"archive\": \"ZIP\",\n" +
+            "        \"compression\": \"NONE\",\n" +
+            "        \"algorithms\": [\n" +
+            "          \"sha512\",\n" +
+            "          \"md5\"\n" +
+            "        ],\n" +
+            "        \"stringkey\": \"stringvalue\",\n" +
+            "        \"arraykey\": [\n" +
+            "          \"arrayvalue\"\n" +
+            "        ]\n" +
+            "}";
 
     @Test
     public void mapOptions() throws IOException {
@@ -48,4 +63,17 @@ public class AssemblerOptionsMappingTest extends AbstractJacksonMappingTest {
         assertTrue(options.getAlgorithms().contains("md5"));
     }
 
+    @Test
+    public void mapOptionsWithAddtionalValues() throws IOException {
+        AssemblerOptions options = mapper.readValue(OPTIONS_CONFIG_ADDITIONAL_VALUES, AssemblerOptions.class);
+
+        assertEquals("ZIP", options.getArchive());
+        assertEquals("NONE", options.getCompression());
+        assertEquals(2, options.getAlgorithms().size());
+        assertTrue(options.getAlgorithms().contains("sha512"));
+        assertTrue(options.getAlgorithms().contains("md5"));
+
+        assertEquals("stringvalue", options.getOptionsMap().get("stringkey"));
+        assertEquals(singletonList("arrayvalue"), options.getOptionsMap().get("arraykey"));
+    }
 }

--- a/shared-resources/src/main/resources/submissions/sample-metadata1.json
+++ b/shared-resources/src/main/resources/submissions/sample-metadata1.json
@@ -6,7 +6,7 @@
     "submittedDate" : "2017-06-02T00:00:00.000Z",
     "aggregatedDepositStatus" : "not-started",
     "publication" : "fake:publication1",
-    "repositories" : [ "fake:repository1", "fake:repository2" ],
+    "repositories" : [ "fake:repository1", "fake:repository2", "fake:repository3" ],
     "submitter" : "fake:user2",
     "grants" : [ "fake:grant1" ],
     "@id" : "fake:submission13",
@@ -48,6 +48,13 @@
     "url" : "http://j10p.com",
     "formSchema" : "{}",
     "@id" : "fake:repository2",
+    "@type" : "Repository"
+  },
+  {
+    "name" : "BagIt Repo",
+    "repositoryKey" : "BagIt",
+    "description" : "Repository for storing bags",
+    "@id" : "fake:repository3",
     "@type" : "Repository"
   },
   {

--- a/shared-resources/src/main/resources/submissions/sample-metadata2.json
+++ b/shared-resources/src/main/resources/submissions/sample-metadata2.json
@@ -6,7 +6,7 @@
     "submittedDate" : "2017-06-02T00:00:00.000Z",
     "aggregatedDepositStatus" : "not-started",
     "publication" : "fake:publication1",
-    "repositories" : [ "fake:repository1", "fake:repository2" ],
+    "repositories" : [ "fake:repository1", "fake:repository2", "fake:repository3" ],
     "submitter" : "fake:user2",
     "grants" : [ "fake:grant1" ],
     "@id" : "fake:submission14",
@@ -48,6 +48,13 @@
     "url" : "http://j10p.com",
     "formSchema" : "{}",
     "@id" : "fake:repository2",
+    "@type" : "Repository"
+  },
+  {
+    "name" : "BagIt Repo",
+    "repositoryKey" : "BagIt",
+    "description" : "Repository for storing bags",
+    "@id" : "fake:repository3",
     "@type" : "Repository"
   },
   {

--- a/shared-resources/src/main/resources/submissions/sample1-no-files.json
+++ b/shared-resources/src/main/resources/submissions/sample1-no-files.json
@@ -7,7 +7,7 @@
     "aggregatedDepositStatus" : "not-started",
     "submissionStatus" : "submitted",
     "publication" : "fake:publication1",
-    "repositories" : [ "fake:repository1", "fake:repository2" ],
+    "repositories" : [ "fake:repository1", "fake:repository2", "fake:repository3" ],
     "submitter" : "fake:user2",
     "grants" : [ "fake:grant1" ],
     "@id" : "fake:submission10",
@@ -49,6 +49,13 @@
     "url" : "http://j10p.com",
     "formSchema" : "{}",
     "@id" : "fake:repository2",
+    "@type" : "Repository"
+  },
+  {
+    "name" : "BagIt Repo",
+    "repositoryKey" : "BagIt",
+    "description" : "Repository for storing bags",
+    "@id" : "fake:repository3",
     "@type" : "Repository"
   },
   {

--- a/shared-resources/src/main/resources/submissions/sample1-unsubmitted.json
+++ b/shared-resources/src/main/resources/submissions/sample1-unsubmitted.json
@@ -7,7 +7,7 @@
     "aggregatedDepositStatus" : "not-started",
     "submissionStatus" : "approval-requested",
     "publication" : "fake:publication1",
-    "repositories" : [ "fake:repository1", "fake:repository2" ],
+    "repositories" : [ "fake:repository1", "fake:repository2", "fake:repository3" ],
     "submitter" : "fake:user2",
     "grants" : [ "fake:grant1" ],
     "@id" : "fake:submission11",
@@ -49,6 +49,13 @@
     "url" : "http://j10p.com",
     "formSchema" : "{}",
     "@id" : "fake:repository2",
+    "@type" : "Repository"
+  },
+  {
+    "name" : "BagIt Repo",
+    "repositoryKey" : "BagIt",
+    "description" : "Repository for storing bags",
+    "@id" : "fake:repository3",
     "@type" : "Repository"
   },
   {

--- a/shared-resources/src/main/resources/submissions/sample1.json
+++ b/shared-resources/src/main/resources/submissions/sample1.json
@@ -7,7 +7,7 @@
     "aggregatedDepositStatus" : "not-started",
     "submissionStatus" : "submitted",
     "publication" : "fake:publication1",
-    "repositories" : [ "fake:repository1", "fake:repository2" ],
+    "repositories" : [ "fake:repository1", "fake:repository2", "fake:repository3" ],
     "submitter" : "fake:user2",
     "grants" : [ "fake:grant1" ],
     "@id" : "fake:submission1",
@@ -49,6 +49,13 @@
     "url" : "http://j10p.com",
     "formSchema" : "{}",
     "@id" : "fake:repository2",
+    "@type" : "Repository"
+  },
+  {
+    "name" : "BagIt Repo",
+    "repositoryKey" : "BagIt",
+    "description" : "Repository for storing bags",
+    "@id" : "fake:repository3",
     "@type" : "Repository"
   },
   {

--- a/shared-resources/src/main/resources/submissions/sample2.json
+++ b/shared-resources/src/main/resources/submissions/sample2.json
@@ -43,6 +43,13 @@
     "@type" : "Repository"
   },
   {
+    "name" : "BagIt Repo",
+    "repositoryKey" : "BagIt",
+    "description" : "Repository for storing bags",
+    "@id" : "fake:repository3",
+    "@type" : "Repository"
+  },
+  {
     "awardNumber" : "R01EY026617",
     "awardStatus" : "active",
     "localKey" : "112233",

--- a/shared-resources/src/main/resources/submissions/sample3-add-figure-and-tables.json
+++ b/shared-resources/src/main/resources/submissions/sample3-add-figure-and-tables.json
@@ -7,7 +7,7 @@
     "aggregatedDepositStatus" : "not-started",
     "submissionStatus" : "submitted",
     "publication" : "fake:publication1",
-    "repositories" : [ "fake:repository1" ],
+    "repositories" : [ "fake:repository1", "fake:repository3" ],
     "submitter" : "fake:user1",
     "grants" : [ "fake:grant1" ],
     "@id" : "fake:submission4",
@@ -39,6 +39,13 @@
     "url" : "http://example.com",
     "formSchema" : "{}",
     "@id" : "fake:repository1",
+    "@type" : "Repository"
+  },
+  {
+    "name" : "BagIt Repo",
+    "repositoryKey" : "BagIt",
+    "description" : "Repository for storing bags",
+    "@id" : "fake:repository3",
     "@type" : "Repository"
   },
   {

--- a/shared-resources/src/main/resources/submissions/sample3-missing-common-md-fields.json
+++ b/shared-resources/src/main/resources/submissions/sample3-missing-common-md-fields.json
@@ -42,6 +42,13 @@
     "@type" : "Repository"
   },
   {
+    "name" : "BagIt Repo",
+    "repositoryKey" : "BagIt",
+    "description" : "Repository for storing bags",
+    "@id" : "fake:repository3",
+    "@type" : "Repository"
+  },
+  {
     "awardNumber" : "R01EY026617",
     "awardStatus" : "active",
     "localKey" : "112233",

--- a/shared-resources/src/main/resources/submissions/sample3-missing-doi.json
+++ b/shared-resources/src/main/resources/submissions/sample3-missing-doi.json
@@ -41,6 +41,13 @@
     "@type" : "Repository"
   },
   {
+    "name" : "BagIt Repo",
+    "repositoryKey" : "BagIt",
+    "description" : "Repository for storing bags",
+    "@id" : "fake:repository3",
+    "@type" : "Repository"
+  },
+  {
     "awardNumber" : "R01EY026617",
     "awardStatus" : "active",
     "localKey" : "112233",

--- a/shared-resources/src/main/resources/submissions/sample3-null-common-md-fields.json
+++ b/shared-resources/src/main/resources/submissions/sample3-null-common-md-fields.json
@@ -42,6 +42,13 @@
     "@type" : "Repository"
   },
   {
+    "name" : "BagIt Repo",
+    "repositoryKey" : "BagIt",
+    "description" : "Repository for storing bags",
+    "@id" : "fake:repository3",
+    "@type" : "Repository"
+  },
+  {
     "awardNumber" : "R01EY026617",
     "awardStatus" : "active",
     "localKey" : "112233",

--- a/shared-resources/src/main/resources/submissions/sample3-null-doi.json
+++ b/shared-resources/src/main/resources/submissions/sample3-null-doi.json
@@ -41,6 +41,13 @@
     "@type" : "Repository"
   },
   {
+    "name" : "BagIt Repo",
+    "repositoryKey" : "BagIt",
+    "description" : "Repository for storing bags",
+    "@id" : "fake:repository3",
+    "@type" : "Repository"
+  },
+  {
     "awardNumber" : "R01EY026617",
     "awardStatus" : "active",
     "localKey" : "112233",

--- a/shared-resources/src/main/resources/submissions/sample3-untrimmed-doi.json
+++ b/shared-resources/src/main/resources/submissions/sample3-untrimmed-doi.json
@@ -42,6 +42,13 @@
     "@type" : "Repository"
   },
   {
+    "name" : "BagIt Repo",
+    "repositoryKey" : "BagIt",
+    "description" : "Repository for storing bags",
+    "@id" : "fake:repository3",
+    "@type" : "Repository"
+  },
+  {
     "awardNumber" : "R01EY026617",
     "awardStatus" : "active",
     "localKey" : "112233",

--- a/shared-resources/src/main/resources/submissions/sample3.json
+++ b/shared-resources/src/main/resources/submissions/sample3.json
@@ -42,6 +42,13 @@
     "@type" : "Repository"
   },
   {
+    "name" : "BagIt Repo",
+    "repositoryKey" : "BagIt",
+    "description" : "Repository for storing bags",
+    "@id" : "fake:repository3",
+    "@type" : "Repository"
+  },
+  {
     "awardNumber" : "R01EY026617",
     "awardStatus" : "active",
     "localKey" : "112233",

--- a/shared-resources/src/main/resources/submissions/sample4-unsubmitted-1repo.json
+++ b/shared-resources/src/main/resources/submissions/sample4-unsubmitted-1repo.json
@@ -7,7 +7,7 @@
     "aggregatedDepositStatus" : "not-started",
     "submissionStatus" : "approval-requested",
     "publication" : "fake:publication1",
-    "repositories" : [ "fake:repository2" ],
+    "repositories" : [ "fake:repository2", "fake:repository3" ],
     "submitter" : "fake:user2",
     "grants" : [ "fake:grant1" ],
     "@id" : "fake:submission12",
@@ -40,6 +40,13 @@
     "url" : "http://j10p.com",
     "formSchema" : "{}",
     "@id" : "fake:repository2",
+    "@type" : "Repository"
+  },
+  {
+    "name" : "BagIt Repo",
+    "repositoryKey" : "BagIt",
+    "description" : "Repository for storing bags",
+    "@id" : "fake:repository3",
     "@type" : "Repository"
   },
   {

--- a/shared-resources/src/main/resources/submissions/sample5-incompleteissn.json
+++ b/shared-resources/src/main/resources/submissions/sample5-incompleteissn.json
@@ -7,7 +7,7 @@
     "aggregatedDepositStatus" : "not-started",
     "submissionStatus" : "submitted",
     "publication" : "fake:publication1",
-    "repositories" : [ "fake:repository1", "fake:repository2" ],
+    "repositories" : [ "fake:repository1", "fake:repository2", "fake:repository3" ],
     "submitter" : "fake:user2",
     "grants" : [ "fake:grant1" ],
     "@id" : "fake:submission15",
@@ -40,6 +40,13 @@
     "url" : "http://example.com",
     "formSchema" : "{}",
     "@id" : "fake:repository1",
+    "@type" : "Repository"
+  },
+  {
+    "name" : "BagIt Repo",
+    "repositoryKey" : "BagIt",
+    "description" : "Repository for storing bags",
+    "@id" : "fake:repository3",
     "@type" : "Repository"
   },
   {

--- a/shared-resources/src/main/resources/submissions/sample6-semi-incompleteissn.json
+++ b/shared-resources/src/main/resources/submissions/sample6-semi-incompleteissn.json
@@ -7,7 +7,7 @@
     "aggregatedDepositStatus" : "not-started",
     "submissionStatus" : "submitted",
     "publication" : "fake:publication1",
-    "repositories" : [ "fake:repository1", "fake:repository2" ],
+    "repositories" : [ "fake:repository1", "fake:repository2", "fake:repository3" ],
     "submitter" : "fake:user2",
     "grants" : [ "fake:grant1" ],
     "@id" : "fake:submission16",
@@ -40,6 +40,13 @@
     "url" : "http://example.com",
     "formSchema" : "{}",
     "@id" : "fake:repository1",
+    "@type" : "Repository"
+  },
+  {
+    "name" : "BagIt Repo",
+    "repositoryKey" : "BagIt",
+    "description" : "Repository for storing bags",
+    "@id" : "fake:repository3",
     "@type" : "Repository"
   },
   {


### PR DESCRIPTION
Provides support for arbitrary Assembler options in the Deposit Services runtime configuration.

Updates test submission graphs by adding a `BagIt` `Repository` resource, and links the `BagIt` `Repository` to the `Submission`.