### PR TITLE
Various improvements in support of BagIt packaging

### DIFF
--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/spring/DepositConfig.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/spring/DepositConfig.java
@@ -332,7 +332,7 @@ public class DepositConfig {
     public ThreadPoolTaskExecutor depositWorkers(DepositServiceErrorHandler errorHandler) {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setMaxPoolSize(depositWorkersConcurrency);
-        executor.setQueueCapacity(10);
+        executor.setQueueCapacity(depositWorkersConcurrency * 2);
         executor.setRejectedExecutionHandler((rejectedTask, exe) -> {
             String msg = String.format(">>>> Task %s@%s rejected, will be retried later.",
                     rejectedTask.getClass().getSimpleName(), toHexString(identityHashCode(rejectedTask)));

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionProcessor.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionProcessor.java
@@ -145,8 +145,8 @@ public class SubmissionProcessor implements Consumer<Submission> {
 
             if (packager == null) {
                 throw new NullPointerException(format("No Packager found for tuple [%s, %s, %s]: " +
-                                "Missing Packager for Repository named '%s'",
-                        submission.getId(), deposit.getId(), repo.getId(), repo.getName()));
+                                "Missing Packager for Repository named '%s' (key: %s)",
+                        submission.getId(), deposit.getId(), repo.getId(), repo.getName(), repo.getRepositoryKey()));
             }
             deposit = passClient.createAndReadResource(deposit, Deposit.class);
         } catch (Exception e) {

--- a/shared-resources/src/main/resources/submissions/sample2.json
+++ b/shared-resources/src/main/resources/submissions/sample2.json
@@ -43,13 +43,6 @@
     "@type" : "Repository"
   },
   {
-    "name" : "BagIt Repo",
-    "repositoryKey" : "BagIt",
-    "description" : "Repository for storing bags",
-    "@id" : "fake:repository3",
-    "@type" : "Repository"
-  },
-  {
     "awardNumber" : "R01EY026617",
     "awardStatus" : "active",
     "localKey" : "112233",

--- a/shared-resources/src/main/resources/submissions/sample3-missing-common-md-fields.json
+++ b/shared-resources/src/main/resources/submissions/sample3-missing-common-md-fields.json
@@ -7,7 +7,7 @@
     "aggregatedDepositStatus" : "not-started",
     "submissionStatus" : "submitted",
     "publication" : "fake:publication1",
-    "repositories" : [ "fake:repository1" ],
+    "repositories" : [ "fake:repository1", "fake:repository3" ],
     "submitter" : "fake:user1",
     "grants" : [ "fake:grant1" ],
     "@id" : "fake:submission5",

--- a/shared-resources/src/main/resources/submissions/sample3-missing-doi.json
+++ b/shared-resources/src/main/resources/submissions/sample3-missing-doi.json
@@ -7,7 +7,7 @@
     "aggregatedDepositStatus" : "not-started",
     "submissionStatus" : "submitted",
     "publication" : "fake:publication1",
-    "repositories" : [ "fake:repository1" ],
+    "repositories" : [ "fake:repository1", "fake:repository3"],
     "submitter" : "fake:user1",
     "grants" : [ "fake:grant1" ],
     "@id" : "fake:submission6",

--- a/shared-resources/src/main/resources/submissions/sample3-null-common-md-fields.json
+++ b/shared-resources/src/main/resources/submissions/sample3-null-common-md-fields.json
@@ -7,7 +7,7 @@
     "aggregatedDepositStatus" : "not-started",
     "submissionStatus" : "submitted",
     "publication" : "fake:publication1",
-    "repositories" : [ "fake:repository1" ],
+    "repositories" : [ "fake:repository1", "fake:repository2", "fake:repository3" ],
     "submitter" : "fake:user1",
     "grants" : [ "fake:grant1" ],
     "@id" : "fake:submission7",

--- a/shared-resources/src/main/resources/submissions/sample3-null-doi.json
+++ b/shared-resources/src/main/resources/submissions/sample3-null-doi.json
@@ -7,7 +7,7 @@
     "aggregatedDepositStatus" : "not-started",
     "submissionStatus" : "submitted",
     "publication" : "fake:publication1",
-    "repositories" : [ "fake:repository1" ],
+    "repositories" : [ "fake:repository1", "fake:repository3" ],
     "submitter" : "fake:user1",
     "grants" : [ "fake:grant1" ],
     "@id" : "fake:submission8",

--- a/shared-resources/src/main/resources/submissions/sample3-untrimmed-doi.json
+++ b/shared-resources/src/main/resources/submissions/sample3-untrimmed-doi.json
@@ -7,7 +7,7 @@
     "aggregatedDepositStatus" : "not-started",
     "submissionStatus" : "submitted",
     "publication" : "fake:publication1",
-    "repositories" : [ "fake:repository1" ],
+    "repositories" : [ "fake:repository1", "fake:repository3" ],
     "submitter" : "fake:user1",
     "grants" : [ "fake:grant1" ],
     "@id" : "fake:submission9",

--- a/shared-resources/src/main/resources/submissions/sample3.json
+++ b/shared-resources/src/main/resources/submissions/sample3.json
@@ -7,7 +7,7 @@
     "aggregatedDepositStatus" : "not-started",
     "submissionStatus" : "submitted",
     "publication" : "fake:publication1",
-    "repositories" : [ "fake:repository1" ],
+    "repositories" : [ "fake:repository1", "fake:repository3" ],
     "submitter" : "fake:user1",
     "grants" : [ "fake:grant1" ],
     "@id" : "fake:submission3",


### PR DESCRIPTION
- Improve error messages
- Fix sample submission graph `sample2.json`, removing the BagIt repository so `DepositTaskIT` doesn't fail.
- Add the BagIt repository to all variants of sample submission graph `sample3.json`
- Scale the capacity of the `DepositTask` worker queue linearly with respect to the thread pool size