### PR TITLE
Filter deposits to repositories with an IntegrationType of 'web-link'

### DIFF
--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionProcessor.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionProcessor.java
@@ -126,7 +126,10 @@ public class SubmissionProcessor implements Consumer<Submission> {
 
         LOG.debug(">>>> Processing Submission {}", submission.getId());
 
-        updatedS.getRepositories().stream().map(repoUri -> passClient.readResource(repoUri, Repository.class))
+        updatedS.getRepositories()
+                .stream()
+                .map(repoUri -> passClient.readResource(repoUri, Repository.class))
+                .filter(repo -> Repository.IntegrationType.WEB_LINK != repo.getIntegrationType())
                 .forEach(repo -> {
                     submitDeposit(updatedS, depositSubmission, repo);
                 });

--- a/shared-resources/src/main/resources/submissions/sample1.json
+++ b/shared-resources/src/main/resources/submissions/sample1.json
@@ -7,7 +7,7 @@
     "aggregatedDepositStatus" : "not-started",
     "submissionStatus" : "submitted",
     "publication" : "fake:publication1",
-    "repositories" : [ "fake:repository1", "fake:repository2", "fake:repository3" ],
+    "repositories" : [ "fake:repository1", "fake:repository2", "fake:repository3", "fake:repository4" ],
     "submitter" : "fake:user2",
     "grants" : [ "fake:grant1" ],
     "@id" : "fake:submission1",
@@ -39,6 +39,7 @@
     "description" : "Contains lots of medical papers",
     "url" : "http://example.com",
     "formSchema" : "{}",
+    "integrationType" : "one-way",
     "@id" : "fake:repository1",
     "@type" : "Repository"
   },
@@ -48,6 +49,7 @@
     "description" : "Knowledge for the world",
     "url" : "http://j10p.com",
     "formSchema" : "{}",
+    "integrationType" : "full",
     "@id" : "fake:repository2",
     "@type" : "Repository"
   },
@@ -55,7 +57,16 @@
     "name" : "BagIt Repo",
     "repositoryKey" : "BagIt",
     "description" : "Repository for storing bags",
+    "integrationType" : "one-way",
     "@id" : "fake:repository3",
+    "@type" : "Repository"
+  },
+  {
+    "name" : "Web Link Repo",
+    "repositoryKey" : "web-link",
+    "description" : "Web-Link only repository",
+    "integrationType" : "web-link",
+    "@id" : "fake:repository4",
     "@type" : "Repository"
   },
   {


### PR DESCRIPTION
Do not perform submissions for [Submission, Deposit, Repository] tuples where the Repository has an IntegrationType of WEB_LINK.

This is due to a behavior change in Ember where all the Repository resources for all IntegrationTypes will be attached to a Submission.  Deposit Services cannot process deposits to WEB_LINK repositories, so it must filter them out before processing.

Closes https://github.com/OA-PASS/deposit-services/issues/235.