### PR TITLE
Update JVM and DNS TTL settings

### DIFF
--- a/deposit-messaging/Dockerfile
+++ b/deposit-messaging/Dockerfile
@@ -39,7 +39,8 @@ ENV DEPOSIT_SERVICES_VERSION=${project.version} \
     PASS_FEDORA_USER=${PASS_FEDORA_USER:-fedoraAdmin} \
     PASS_FEDORA_PASSWORD=${PASS_FEDORA_PASSWORD:-moo} \
     PASS_ELASTICSEARCH_LIMIT=${PASS_ELASTICSEARCH_LIMIT:-100} \
-    PASS_DEPOSIT_REPOSITORY_CONFIGURATION=${PASS_DEPOSIT_REPOSITORY_CONFIGURATION:-classpath:/repositories.json}
+    PASS_DEPOSIT_REPOSITORY_CONFIGURATION=${PASS_DEPOSIT_REPOSITORY_CONFIGURATION:-classpath:/repositories.json} \
+    IMAGE_JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk/jre
 
 ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${DEPOSIT_DEBUG_PORT}
 
@@ -50,7 +51,7 @@ RUN apk update && \
     pip install awscli && \
     chmod 700 /bin/aws_entrypoint.sh && \
     mkdir /app && \
-    echo "networkaddress.cache.ttl=10" >> ${JAVA_HOME}/lib/security/java.security
+    echo "networkaddress.cache.ttl=10" >> ${IMAGE_JAVA_HOME}/lib/security/java.security
 
 COPY ${project.build.directory}/${project.artifactId}-${project.version}-exec.jar .
 

--- a/deposit-messaging/Dockerfile
+++ b/deposit-messaging/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u151-jdk-alpine3.7
+FROM openjdk:8u212-jre-alpine3.9@sha256:5c5867cd2d4d198d1e53562c8202dfa388832b6f7d8276e69eae212b326c7777
 
 LABEL version=${project.parent.version}
 LABEL commit=${git.commit.id.abbrev}
@@ -49,7 +49,8 @@ RUN apk update && \
     apk add --no-cache ca-certificates wget python py-pip && \
     pip install awscli && \
     chmod 700 /bin/aws_entrypoint.sh && \
-    mkdir /app
+    mkdir /app && \
+    echo "networkaddress.cache.ttl=10" >> ${JAVA_HOME}/lib/security/java.security
 
 COPY ${project.build.directory}/${project.artifactId}-${project.version}-exec.jar .
 

--- a/deposit-messaging/Dockerfile
+++ b/deposit-messaging/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u212-jre-alpine3.9@sha256:5c5867cd2d4d198d1e53562c8202dfa388832b6f7d8276e69eae212b326c7777
+FROM openjdk:8u151-jdk-alpine3.7@sha256:bd4030dd52cfb61a61e622fe74483e4e2089a2ef3d782bbf742a0d99093da119
 
 LABEL version=${project.parent.version}
 LABEL commit=${git.commit.id.abbrev}


### PR DESCRIPTION
Updates the Dockerfile to update to openJDK_212, and change DNS ttl to 10 seconds.

Note:  The Docker build fails on Windows for a silly reason.  Let's see if Travis does better:

    echo \"networkaddress.cache.ttl=10\" >> C:/Program Files/Java/jdk1.8.0_131/lib/security/java.security' returned a non-zero code: 1"