### PR TITLE
Ignore ISSNs with unknown publication types

### DIFF
--- a/deposit-model/src/main/java/org/dataconservancy/pass/deposit/model/DepositMetadata.java
+++ b/deposit-model/src/main/java/org/dataconservancy/pass/deposit/model/DepositMetadata.java
@@ -19,6 +19,7 @@ package org.dataconservancy.pass.deposit.model;
 import java.net.URI;
 import java.net.URL;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -462,6 +463,13 @@ public class DepositMetadata {
         public void setType(PERSON_TYPE type) {
             this.type = type;
         }
+    }
+
+    public DepositMetadata() {
+        this.manuscriptMetadata = new Manuscript();
+        this.journalMetadata = new Journal();
+        this.articleMetadata = new Article();
+        this.persons = new ArrayList<>();
     }
 
     public Manuscript getManuscriptMetadata() {

--- a/fedora-builder/src/main/java/org/dataconservancy/pass/deposit/builder/fs/ModelBuilder.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/pass/deposit/builder/fs/ModelBuilder.java
@@ -287,7 +287,7 @@ abstract class ModelBuilder {
      * @param metadataStr
      * @throws InvalidModel
      */
-    private void processMetadata(DepositMetadata depositMetadata, String metadataStr)
+    void processMetadata(DepositMetadata depositMetadata, String metadataStr)
             throws InvalidModel {
         JsonObject json = new JsonParser().parse(metadataStr).getAsJsonObject();
         processCommonMetadata(depositMetadata, json);

--- a/fedora-builder/src/main/java/org/dataconservancy/pass/deposit/builder/fs/ModelBuilder.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/pass/deposit/builder/fs/ModelBuilder.java
@@ -234,8 +234,7 @@ abstract class ModelBuilder {
                 } catch (Exception e) {
                     // Shouldn't happen.  If ISSNs can't be parsed, then they should be ignored, and not included
                     // in the Journal metadata
-                    LOG.warn("Unable to parse ISSNs from '{}'", issnObjAsStr, e);
-                    throw new RuntimeException(e);
+                    LOG.warn("Unable to parse ISSNs from '{}'", issnObjAsStr);
                 }
             });
         });


### PR DESCRIPTION
Prior to this PR, Deposit Services would throw an Exception if an unknown ISSN publication type was encountered in the metadata blob (the consequences of this would be a failure of the submission!).  

This PR updates that behavior to simply issuing a logging statement at `WARN` level, stating that an unparsable ISSN publication type was encountered.  The unparsable ISSN is *not* included in `DepositMetadata.Journal`.

Clients that rely on `DepositMetadata.Journal` will notice *no changes*.  With prior behavior, if an invalid publication type was encountered, the submission would be failed before clients could examine `DepositMetadata.Journal` (i.e. the client would never see an invalid publication type).  With this change, clients will never see an ISSN with an invalid publication type, including ISSNs with _no_ publication type.

See also the discussion on OA-PASS/metadata-schemas#28