### PR TITLE
Include submitted date in the Deposit model

### DIFF
--- a/deposit-model/pom.xml
+++ b/deposit-model/pom.xml
@@ -27,4 +27,11 @@
     <artifactId>deposit-model</artifactId>
     <name>Submission Model</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/deposit-model/src/main/java/org/dataconservancy/pass/deposit/model/DepositSubmission.java
+++ b/deposit-model/src/main/java/org/dataconservancy/pass/deposit/model/DepositSubmission.java
@@ -15,7 +15,10 @@
  */
 package org.dataconservancy.pass.deposit.model;
 
+import org.joda.time.DateTime;
+
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Encapsulates a submission to the target system, including the manuscript and supplement files, metadata describing
@@ -29,6 +32,13 @@ public class DepositSubmission {
      * Internal, submission engine, identifier
      */
     private String id;
+
+    /**
+     * Date the Submission resource was submitted to the PASS repository.
+     *
+     * Set by Ember when the user clicks the Submit button
+     */
+    private DateTime submissionDate;
 
     /**
      * Manifest containing an entry for each file in the submission
@@ -90,34 +100,47 @@ public class DepositSubmission {
         this.name = name;
     }
 
+    /**
+     * Date the Submission resource was submitted to the PASS repository.
+     *
+     * Set by Ember when the user clicks the Submit button
+     */
+    public DateTime getSubmissionDate() {
+        return submissionDate;
+    }
+
+    /**
+     * Date the Submission resource was submitted to the PASS repository.
+     *
+     * Set by Ember when the user clicks the Submit button
+     */
+    public void setSubmissionDate(DateTime submissionDate) {
+        this.submissionDate = submissionDate;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         DepositSubmission that = (DepositSubmission) o;
-
-        if (id != null ? !id.equals(that.id) : that.id != null) return false;
-        if (manifest != null ? !manifest.equals(that.manifest) : that.manifest != null) return false;
-        if (metadata != null ? !metadata.equals(that.metadata) : that.metadata != null) return false;
-        if (files != null ? !files.equals(that.files) : that.files != null) return false;
-        return name != null ? name.equals(that.name) : that.name == null;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(submissionDate, that.submissionDate) &&
+                Objects.equals(manifest, that.manifest) &&
+                Objects.equals(metadata, that.metadata) &&
+                Objects.equals(files, that.files) &&
+                Objects.equals(name, that.name);
     }
 
     @Override
     public int hashCode() {
-        int result = id != null ? id.hashCode() : 0;
-        result = 31 * result + (manifest != null ? manifest.hashCode() : 0);
-        result = 31 * result + (metadata != null ? metadata.hashCode() : 0);
-        result = 31 * result + (files != null ? files.hashCode() : 0);
-        result = 31 * result + (name != null ? name.hashCode() : 0);
-        return result;
+        return Objects.hash(id, submissionDate, manifest, metadata, files, name);
     }
 
     @Override
     public String toString() {
         return "DepositSubmission{" +
                 "id='" + id + '\'' +
+                ", submissionDate=" + submissionDate +
                 ", manifest=" + manifest +
                 ", metadata=" + metadata +
                 ", files=" + files +

--- a/fedora-builder/src/main/java/org/dataconservancy/pass/deposit/builder/fs/ModelBuilder.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/pass/deposit/builder/fs/ModelBuilder.java
@@ -25,7 +25,6 @@ import org.dataconservancy.pass.deposit.model.DepositFileType;
 import org.dataconservancy.pass.deposit.model.DepositManifest;
 import org.dataconservancy.pass.deposit.model.DepositMetadata;
 import org.dataconservancy.pass.deposit.model.DepositSubmission;
-import org.dataconservancy.pass.deposit.model.JournalPublicationType;
 import org.dataconservancy.pass.model.File;
 import org.dataconservancy.pass.model.Grant;
 import org.dataconservancy.pass.model.PassEntity;
@@ -325,6 +324,8 @@ abstract class ModelBuilder {
         submission.setId(submissionEntity.getId().toString());
         // The deposit data model requires a "name" - for now we use the ID.
         submission.setName(submissionEntity.getId().toString());
+        
+        submission.setSubmissionDate(submissionEntity.getSubmittedDate());
 
         // Data from the Submission's user resource
       

--- a/fedora-builder/src/test/java/org/dataconservancy/pass/deposit/builder/fs/FilesystemModelBuilderTest.java
+++ b/fedora-builder/src/test/java/org/dataconservancy/pass/deposit/builder/fs/FilesystemModelBuilderTest.java
@@ -25,6 +25,8 @@ import org.dataconservancy.pass.deposit.model.DepositSubmission;
 import org.dataconservancy.pass.deposit.model.JournalPublicationType;
 import org.dataconservancy.pass.model.PassEntity;
 import org.dataconservancy.pass.model.Submission;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
 import org.junit.Before;
 import org.junit.Test;
 import submissions.SubmissionResourceUtil;
@@ -50,7 +52,11 @@ import java.util.Map;
 public class FilesystemModelBuilderTest {
 
     private static final String EXPECTED_TITLE = "Food & Function";
+
     private static final String EXPECTED_PUB_DATE = "2018-09-12";
+
+    private static final DateTime EXPECTED_SUBMITTED_DATE =
+            DateTime.parse("2017-06-02T00:00:00.000Z", DateTimeFormat.forPattern("YYYY-M-d'T'H':'m':'s'.'SSSZ").withZoneUTC());
 
     private static final Map<String, JournalPublicationType> EXPECTED_ISSN_PUBTYPES =
             new HashMap<String, JournalPublicationType>() {
@@ -124,6 +130,7 @@ public class FilesystemModelBuilderTest {
 
         assertEquals(submission.getId(), submissionEntity.getId().toString());
         assertEquals(EXPECTED_DOI, submission.getMetadata().getArticleMetadata().getDoi().toString());
+        assertEquals(EXPECTED_SUBMITTED_DATE, submission.getSubmissionDate());
 
         assertNotNull(submission.getFiles());
         assertEquals(8, submission.getFiles().size());


### PR DESCRIPTION
Submission.submittedDate is set by Ember on the Submission when the user clicks the Submit button.

This PR includes the Submission.submittedDate in the Deposit model, on the DepositSubmission.