### PR TITLE
Update the FilesystemBuilder to optionally deposit resources to Fedora

### DIFF
--- a/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/builder/fedora/FcrepoModelBuilderIT.java
+++ b/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/builder/fedora/FcrepoModelBuilderIT.java
@@ -93,7 +93,7 @@ public class FcrepoModelBuilderIT {
         // Upload sample data to Fedora repository to get its Submission URI.
         URI submissionUri;
         try (InputStream is = lookupStream(SAMPLE_SUBMISSION_RESOURCE)) {
-            submissionUri = adapter.jsonToFcrepo(is, entities);
+            submissionUri = adapter.jsonToFcrepo(is, entities).getId();
         }
 
         // Find the Submission entity that was uploaded

--- a/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/builder/fedora/PassJsonFedoraAdapterIT.java
+++ b/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/builder/fedora/PassJsonFedoraAdapterIT.java
@@ -71,7 +71,7 @@ public class PassJsonFedoraAdapterIT {
             // Upload the sample data to the Fedora repo.
             URI submissionUri;
             try (InputStream is = lookupStream(SAMPLE_DATA_FILE)) {
-                submissionUri = adapter.jsonToFcrepo(is, entities);
+                submissionUri = adapter.jsonToFcrepo(is, entities).getId();
             }
 
             // Download the data from the server to a temporary JSON file

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/spring/DepositConfig.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/spring/DepositConfig.java
@@ -21,6 +21,7 @@ import okhttp3.Request;
 import okhttp3.logging.HttpLoggingInterceptor;
 import org.apache.abdera.parser.Parser;
 import org.apache.abdera.parser.stax.FOMParserFactory;
+import org.dataconservancy.pass.client.PassClient;
 import org.dataconservancy.pass.client.PassClientDefault;
 import org.dataconservancy.pass.client.SubmissionStatusService;
 import org.dataconservancy.pass.client.adapter.PassJsonAdapterBasic;
@@ -164,8 +165,8 @@ public class DepositConfig {
     }
 
     @Bean
-    public FilesystemModelBuilder fileSystemModelBuilder() {
-        return new FilesystemModelBuilder();
+    public FilesystemModelBuilder fileSystemModelBuilder(PassClient passClient) {
+        return new FilesystemModelBuilder(passClient);
     }
 
     @Bean

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/spring/DepositConfig.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/spring/DepositConfig.java
@@ -42,9 +42,6 @@ import org.dataconservancy.pass.deposit.messaging.status.DepositStatusProcessor;
 import org.dataconservancy.pass.deposit.messaging.status.DepositStatusResolver;
 import org.dataconservancy.pass.deposit.messaging.support.swordv2.AtomFeedStatusResolver;
 import org.dataconservancy.pass.deposit.transport.Transport;
-import org.dataconservancy.pass.deposit.transport.fs.FilesystemTransport;
-import org.dataconservancy.pass.deposit.transport.ftp.FtpTransport;
-import org.dataconservancy.pass.deposit.transport.sword2.Sword2Transport;
 import org.dataconservancy.pass.support.messaging.cri.CriticalRepositoryInteraction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,7 +58,6 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.net.URI;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ThreadFactory;
@@ -165,8 +161,8 @@ public class DepositConfig {
     }
 
     @Bean
-    public FilesystemModelBuilder fileSystemModelBuilder(PassClient passClient) {
-        return new FilesystemModelBuilder(passClient);
+    public FilesystemModelBuilder fileSystemModelBuilder() {
+        return new FilesystemModelBuilder(true);
     }
 
     @Bean

--- a/fedora-builder/src/main/java/org/dataconservancy/pass/deposit/builder/fs/FilesystemModelBuilder.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/pass/deposit/builder/fs/FilesystemModelBuilder.java
@@ -16,6 +16,7 @@
 
 package org.dataconservancy.pass.deposit.builder.fs;
 
+import org.dataconservancy.pass.client.PassClient;
 import org.dataconservancy.pass.deposit.builder.InvalidModel;
 import org.dataconservancy.pass.deposit.builder.StreamingSubmissionBuilder;
 import org.dataconservancy.pass.deposit.builder.SubmissionBuilder;
@@ -29,29 +30,91 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Builds a submission from a file on a locally mounted filesystem.
- * The file contains JSON data representing PassEntity objects that have unique IDs and link to each other.
- * The file must contain a single Submission object, which is the root of the data tree for a deposit.
+ * Builds an instance of the Deposit Services model (i.e. a {@link DepositSubmission} from a file on a locally mounted
+ * filesystem.
+ * <p>
+ * The file is JSON data representing a graph of PassEntity objects.  Each object must have a unique ID. The entities in
+ * the JSON are linked together by their identifiers to form the graph, rooted with the Submission object.  The file
+ * must contain exactly one Submission object, which is the root of the data tree for a deposit.
+ * </p>
+ * <p>
+ * If a {@link PassClient} is provided on construction, the resources present in the local graph will be deposited to
+ * the PASS repository.  This results in a new Fedora resource for each resource present in the JSON graph.  The
+ * map of local resource identifiers to PASS repository identifiers is obtained by calling {@link #getUriMap()} after
+ * invoking one of the {@link #build(String)} or {@link #build(InputStream, Map)} methods.
+ * </p>
  *
  * @author Ben Trumbore (wbt3@cornell.edu)
+ * @author Elliot Metsger (emetsger@jhu.edu)
  */
 public class FilesystemModelBuilder extends ModelBuilder implements SubmissionBuilder, StreamingSubmissionBuilder {
 
+    /**
+     * Must be non-null if {@link #depositToPass} is {@code true}.
+     */
+    private PassClient passClient;
+
+    /**
+     * Indicates whether or not the PASS resources read from the local JSON should have equivalent resources deposited
+     * to the PASS repository.  If this flag is {@code true}, then a {@link #passClient PASS client} <em>must</em>
+     * be supplied on {@link #FilesystemModelBuilder(PassClient) construction}.
+     */
+    private boolean depositToPass = false;
+
+    /**
+     * If local PASS resources are deposited to the PASS repository, this map will be keyed by the local PASS resource
+     * URI, mapping to the PASS repository URI.
+     */
+    private ThreadLocal<Map<URI, URI>> uriMap = ThreadLocal.withInitial(HashMap::new);
+
+    private PassJsonFedoraAdapter adapter = new PassJsonFedoraAdapter();
+
+    /**
+     * Constructs a builder that will build local resources, but not deposit them to Fedora.
+     */
+    public FilesystemModelBuilder() {
+
+    }
+
+    /**
+     * Constructs a builder that deposits newly built resources to Fedora.
+     *
+     * @param passClient the PASS client used to deposit newly built resources to Fedora
+     */
+    public FilesystemModelBuilder(PassClient passClient) {
+        this.passClient = passClient;
+        this.depositToPass = true;
+    }
+
     /***
      * Build a DepositSubmission from the JSON data in named file.
-     * @param formDataUrl url to the local file containing the JSON data
+     * <p>
+     * Supported forms of {@code formDataUrl} include:
+     * </p>
+     * <ul>
+     *     <li>{@code http://} or {@code https//}</li>
+     *     <li>{@code file:/}</li>
+     *     <li>{@code jar:/}</li>
+     * </ul>
+     * <p>
+     * If there is no scheme present, {@code formDataUrl} is interpreted as a path to a local file containing the JSON
+     * data.
+     * </p>
+     *
+     * @param formDataUrl url containing the JSON data
      * @return a deposit submission data model
      * @throws InvalidModel if the JSON data cannot be successfully parsed into a valid submission model
      */
     @Override
     public DepositSubmission build(String formDataUrl) throws InvalidModel {
+        InputStream is = null;
         try {
             URI resource = new URI(formDataUrl);
-            InputStream is;
 
             if (resource.getScheme() == null) {
                 is = new FileInputStream(formDataUrl);
@@ -64,26 +127,113 @@ public class FilesystemModelBuilder extends ModelBuilder implements SubmissionBu
                         resource.getScheme(), formDataUrl));
             }
 
-
-            PassJsonFedoraAdapter reader = new PassJsonFedoraAdapter();
-            HashMap<URI, PassEntity> entities = new HashMap<>();
-            Submission submissionEntity = reader.jsonToPass(is, entities);
-            is.close();
-            return createDepositSubmission(submissionEntity, entities);
+            return build(is, Collections.emptyMap());
         } catch (FileNotFoundException e) {
             throw new InvalidModel(String.format("Could not open the data file '%s'.", formDataUrl), e);
         } catch (IOException e) {
             throw new InvalidModel(String.format("Failed to close the data file '%s'.", formDataUrl), e);
         } catch (URISyntaxException e) {
             throw new InvalidModel(String.format("Malformed URL '%s'.", formDataUrl), e);
+        } finally {
+            if (is != null) {
+                try {
+                    is.close();
+                } catch (IOException e) {
+                    // ignore
+                }
+            }
         }
     }
 
+    /***
+     * Build a DepositSubmission from JSON data provided in an {@code InputStream}.  This method can be used to bypass
+     * the URL resolution logic in {@link #build(String)}.
+     *
+     * @param stream the InputStream containing the submission graph
+     * @return a deposit submission data model
+     * @throws InvalidModel if the JSON data cannot be successfully parsed into a valid submission model
+     */
     @Override
     public DepositSubmission build(InputStream stream, Map<String, String> streamMd) throws InvalidModel {
         PassJsonFedoraAdapter reader = new PassJsonFedoraAdapter();
         HashMap<URI, PassEntity> entities = new HashMap<>();
         Submission submissionEntity = reader.jsonToPass(stream, entities);
+
+        reader.jsonToFcrepo(stream, )
+
         return createDepositSubmission(submissionEntity, entities);
     }
+
+    /**
+     * The PASS client used to deposit local resources to Fedora.
+     *
+     * @return the PASS client, may be {@code null}
+     * @see #FilesystemModelBuilder(PassClient)
+     */
+    public PassClient getPassClient() {
+        return passClient;
+    }
+
+    /**
+     * The PASS client used to deposit local resources to Fedora.
+     *
+     * @param passClient the PASS client
+     * @see #FilesystemModelBuilder(PassClient)
+     */
+    public void setPassClient(PassClient passClient) {
+        this.passClient = passClient;
+    }
+
+    /**
+     * If {@code true}, and if {@link #getPassClient()} is <em>not</em> {@code null}, then this builder will deposit
+     * each locally built resource to Fedora.
+     *
+     * @return whether or not to use a {@code PassClient} to deposit locally built resources to Fedora
+     */
+    public boolean isDepositToPass() {
+        return depositToPass;
+    }
+
+    /**
+     * If {@code true}, and if {@link #getPassClient()} is <em>not</em> {@code null}, then this builder will deposit
+     * each locally built resource to Fedora.
+     *
+     * @param depositToPass whether or not to use a {@code PassClient} to deposit locally built resources to Fedora
+     */
+    public void setDepositToPass(boolean depositToPass) {
+        this.depositToPass = depositToPass;
+    }
+
+    /**
+     * Returns a mapping of local PASS entity URIs and their equivalent resources in Fedora.
+     * <p>
+     * This map will be empty if {@link #isDepositToPass()} is {@code false}.  If {@link #isDepositToPass()} is {@code
+     * true} <em>and</em> {@link #getPassClient()} is not {@code null}, this map will be populated after each call to
+     * either {@code build(...)} method.
+     * </p>
+     * <p>
+     * This builder is typically instantiated as a singleton.  In order to avoid cross-talk between multiple threads
+     * invoking the {@code build(...)} methods, the underlying {@code Map} is managed as a {@code ThreadLocal}.  This
+     * means that a caller ought to be able to perform:
+     * </p>
+     * <ol>
+     *     <li>{@link #build(String)}</li>
+     *     <li>{@link #getUriMap()}</li>
+     *     <li><em>read results from map</em></li>
+     *     <li>{@code getUriMap().clear()}</li>
+     *     <li><em>builder ready for next invocation</em></li>
+     * </ol>
+     * <p>
+     * Note that this map will grow unless cleared by the caller.
+     * </p>
+     *
+     * @return a map of local entity URIs to Fedora entity URIs
+     * @see #FilesystemModelBuilder(PassClient)
+     * @see #setPassClient(PassClient)
+     * @see #setDepositToPass(boolean)
+     */
+    public Map<URI, URI> getUriMap() {
+        return uriMap.get();
+    }
+
 }

--- a/fedora-builder/src/main/java/org/dataconservancy/pass/deposit/builder/fs/ModelBuilder.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/pass/deposit/builder/fs/ModelBuilder.java
@@ -54,7 +54,7 @@ import static org.dataconservancy.pass.deposit.model.JournalPublicationType.pars
  */
 abstract class ModelBuilder {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ModelBuilder.class);
+    static final Logger LOG = LoggerFactory.getLogger(ModelBuilder.class);
 
     private static final String ISSNS = "issns";
 

--- a/fedora-builder/src/main/java/org/dataconservancy/pass/deposit/builder/fs/PassJsonFedoraAdapter.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/pass/deposit/builder/fs/PassJsonFedoraAdapter.java
@@ -188,9 +188,9 @@ public class PassJsonFedoraAdapter {
      * pass.fedora.user and pass.fedora.password system properties.
      *
      * @param entities the PassEntity objects to upload.  Keys are updated to be URIs on the Fedora server.
-     * @return the URI on the Fedora server of the newly created Submission resource.
+     * @return the newly created Submission resource from Fedora.
      */
-    public URI passToFcrepo(HashMap<URI, PassEntity> entities) {
+    public Submission passToFcrepo(HashMap<URI, PassEntity> entities) {
         PassClient client = PassClientFactory.getPassClient();
         HashMap<URI, URI> uriMap = new HashMap<>();
         URI submissionUri = null;
@@ -256,7 +256,7 @@ public class PassJsonFedoraAdapter {
         entities.values().stream().filter(e -> e instanceof File)
                 .forEach(f -> uploadBinaryToSubmission(repoSubmission, (File) f, client));
 
-        return submissionUri;
+        return repoSubmission;
     }
 
     /**
@@ -437,9 +437,9 @@ public class PassJsonFedoraAdapter {
      * pass.fedora.user and pass.fedora.password system properties.
      *
      * @param is the stream containing the JSON data.
-     * @return the RUI of the root Submission resource on the Fedora server.
+     * @return the root Submission resource on the Fedora server.
      */
-    public URI jsonToFcrepo(InputStream is) {
+    public Submission jsonToFcrepo(InputStream is) {
         HashMap<URI, PassEntity> entities = new HashMap<>();
         return jsonToFcrepo(is, entities);
     }
@@ -457,9 +457,9 @@ public class PassJsonFedoraAdapter {
      *
      * @param is the stream containing the JSON data.
      * @param entities a map which will be filled with all uploaded PassEntities.
-     * @return the RUI of the root Submission resource on the Fedora server.
+     * @return the root Submission resource on the Fedora server.
      */
-    public URI jsonToFcrepo(InputStream is, HashMap<URI, PassEntity> entities) {
+    public Submission jsonToFcrepo(InputStream is, HashMap<URI, PassEntity> entities) {
         entities.clear();
         jsonToPass(is, entities);
         return passToFcrepo(entities);

--- a/shared-integration/src/test/java/org/dataconservancy/pass/deposit/integration/shared/AbstractSubmissionFixture.java
+++ b/shared-integration/src/test/java/org/dataconservancy/pass/deposit/integration/shared/AbstractSubmissionFixture.java
@@ -118,7 +118,7 @@ public abstract class AbstractSubmissionFixture {
         HashMap<URI, PassEntity> uriMap = new HashMap<>();
 
         // Upload sample data to Fedora repository to get its Submission URI.
-        URI submissionUri = passAdapter.jsonToFcrepo(submissionGraph, uriMap);
+        URI submissionUri = passAdapter.jsonToFcrepo(submissionGraph, uriMap).getId();
 
         // Find the Submission entity that was uploaded
         Submission submission = findSubmission(uriMap);

--- a/shared-integration/src/test/java/org/dataconservancy/pass/deposit/integration/shared/SubmitAndValidatePackagesIT.java
+++ b/shared-integration/src/test/java/org/dataconservancy/pass/deposit/integration/shared/SubmitAndValidatePackagesIT.java
@@ -514,7 +514,7 @@ public abstract class SubmitAndValidatePackagesIT extends AbstractSubmissionFixt
 
             LOG.info("Creating Submission in the Fedora repository for {}", localSubmissionUri);
             Future<URI> passSubmissionUri =
-                    itExecutorService.submit(() -> passAdapter.jsonToFcrepo(toInputStream(root), submissionMap));
+                    itExecutorService.submit(() -> passAdapter.jsonToFcrepo(toInputStream(root), submissionMap).getId());
             futureSubmissions.put(passSubmissionUri, submissionMap);
         }
 


### PR DESCRIPTION
## About

The `SubmissionBuilder` and `StreamingSubmissionBuilder` are interfaces responsible for building the Deposit Services model of a PASS `Submission`: a `DepositSubmission`.

Two concrete implementations exist:
- `FcrepoModelBuilder`: given a `Submission` _URL_, it will retrieve the `Submission` resource and its linked resources (i.e. the "submission graph") and build a `DepositSubmission`.  All URIs present in the `DepositSubmission` point to Fedora resources.
- `FilesystemModelBuilder`: given a `Submission` URI, it resolves the URI to a resource on the test class path that contains the submission graph, and builds the `DepositSubmission`.  All URIs present in the `DepositSubmission` are local URIs suitable for linking the resources in the graph, but are not resolvable as HTTP resources.

## Changes

This PR updates the `FilesystemModelBuilder` to optionally deposit the test resources in the submission graph to Fedora, and build the `DepositSubmission` from the Fedora resources.  The URIs in the `DepositSubmission` would therefore point to Fedora resources.

## Rationale

The DASH Package Provider includes funding information in the package.  It obtains this information from the `Grant` and `Funder` resources linked to by the `Submission`.  The Deposit Services model (e.g. `DepositSubmission`) doesn't contain this information, so the DASH provider must resolve the `Submission` resource and navigate and retrieve `Grant` and `Funder` resources.  In order for the DASH provider to resolve these resources without providing special handling for test resources, the `FilesystemModelBuilder` must present a `DepositSubmission` with resolvable URIs instead of local test resources.

In other words, a `DepositSubmission` using local URIs doesn't really behave like linked data, because the local URIs aren't resolvable.  The `DepositSubmission` must be built from Fedora resources in order for linking to work as expected.

