### PR TITLE
Fix errant log message

### DIFF
--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositTaskHelper.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositTaskHelper.java
@@ -195,7 +195,9 @@ public class DepositTaskHelper {
                 }
             }
 
-            LOG.error(format("Failed to update Deposit %s", depositUri));
+            LOG.debug(format("Failed to update Deposit %s: no cause was present, probably a pre- or post-condition " +
+                    "was not satisfied.", depositUri));
+            return;
         }
     }
 


### PR DESCRIPTION
Missed a return, so a success message was logged accidentally.  Reduce the log level to DEBUG for what is probably a benign reason.