### PR TITLE
Update the git properties file name

### DIFF
--- a/deposit-messaging/pom.xml
+++ b/deposit-messaging/pom.xml
@@ -37,7 +37,7 @@
                 <configuration>
                     <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
-                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/deposit-services-git.properties</generateGitPropertiesFilename>
                     <failOnNoGitDirectory>false</failOnNoGitDirectory>
                     <abbrevLength>8</abbrevLength>
                 </configuration>

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/DepositApp.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/DepositApp.java
@@ -69,7 +69,7 @@ public class DepositApp {
 
     private String fcrepoBaseUrl;
 
-    private static final String GIT_PROPERTIES_RESOURCE_PATH = "/git.properties";
+    private static final String GIT_PROPERTIES_RESOURCE_PATH = "/deposit-services-git.properties";
 
     public static void main(String[] args) {
 


### PR DESCRIPTION
This renames `git.properties` to `deposit-services-git.properties`, insuring that if the contents of this jar are ever assembled as an uber jar, other resources named `git.properties` won't conflict.