### PR TITLE
Uses conditional updates when interacting with repository resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <pass-client.version>0.6.0</pass-client.version>
         <fast-classpath-scanner.version>3.1.5</fast-classpath-scanner.version>
         <jackson.version>2.9.6</jackson.version>
-        <messaging-support.version>0.1.2-3.4</messaging-support.version>
+        <messaging-support.version>0.1.3-3.4-SNAPSHOT</messaging-support.version>
 
         <!-- oapass/fcrepo:4.7.5-3.4 -->
         <docker.fcrepo.version>oapass/fcrepo@sha256:3e39b01edf56c149279cfc51b647df335c01f9ec38036f1724f337ae35d68fe8</docker.fcrepo.version>


### PR DESCRIPTION
Upgrade the messaging-support library to 0.1.3-3.4-SNAPSHOT from 0.1.2-3.4.

The `CriticalPath` class in version `0.1.2-3.4` of the library would _always_  issue updates of repository resources (via HTTP PATCH using the PASS Java client), even if the state of the resource wasn't modified by the caller. 

Instead of updating the repository resource each time, the upgraded `CriticalPath` will conditionally update the repository resource only when it has been modified locally.

See also: https://github.com/OA-PASS/messaging-support/pull/4