### PR TITLE
Support runtime configuration of logging levels

### DIFF
--- a/deposit-messaging/pom.xml
+++ b/deposit-messaging/pom.xml
@@ -294,7 +294,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <scope>runtime</scope>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/DepositApp.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/DepositApp.java
@@ -82,29 +82,7 @@ public class DepositApp {
 
         configureLoggingRuntime();
 
-        URL gitPropertiesResource = DepositApp.class.getResource(GIT_PROPERTIES_RESOURCE_PATH);
-        if (gitPropertiesResource == null) {
-            LOG.info("Starting DepositServices (no Git commit information available)");
-        } else {
-            Properties gitProperties = new Properties();
-            try {
-                gitProperties.load(gitPropertiesResource.openStream());
-                boolean isDirty = Boolean.valueOf(gitProperties.getProperty(GIT_DIRTY_FLAG));
-
-            LOG.info("Starting DepositServices (version: {} branch: {} commit: {} commit date: {} build date: {})",
-                    gitProperties.get(GIT_BUILD_VERSION_KEY),
-                    gitProperties.get(GIT_BRANCH),
-                    gitProperties.get(GIT_COMMIT_HASH_KEY),
-                    gitProperties.get(GIT_COMMIT_TIME_KEY),
-                    gitProperties.get(GIT_BUILD_TIME));
-
-                if (isDirty) {
-                    LOG.warn("** Deposit Services was compiled from a Git repository with uncommitted changes! **");
-                }
-            } catch (IOException e) {
-                LOG.warn("Starting DepositService (" + GIT_PROPERTIES_RESOURCE_PATH + " could not be parsed: " + e.getMessage() + ")");
-            }
-        }
+        logStartup();
 
         if (args.length < 1 || args[0] == null) {
             throw new IllegalArgumentException("Requires at least one argument!");
@@ -195,6 +173,32 @@ public class DepositApp {
                     String nameString = StringUtils.rightPad(varName, maxLen);
                     LOG.info("   {} '{}' {}", nameString, resolvedValue, errorMsg);
                 }
+            }
+        }
+    }
+
+    private static void logStartup() {
+        URL gitPropertiesResource = DepositApp.class.getResource(GIT_PROPERTIES_RESOURCE_PATH);
+        if (gitPropertiesResource == null) {
+            LOG.info("Starting DepositServices (no Git commit information available)");
+        } else {
+            Properties gitProperties = new Properties();
+            try {
+                gitProperties.load(gitPropertiesResource.openStream());
+                boolean isDirty = Boolean.valueOf(gitProperties.getProperty(GIT_DIRTY_FLAG));
+
+                LOG.info("Starting DepositServices (version: {} branch: {} commit: {} commit date: {} build date: {})",
+                        gitProperties.get(GIT_BUILD_VERSION_KEY),
+                        gitProperties.get(GIT_BRANCH),
+                        gitProperties.get(GIT_COMMIT_HASH_KEY),
+                        gitProperties.get(GIT_COMMIT_TIME_KEY),
+                        gitProperties.get(GIT_BUILD_TIME));
+
+                if (isDirty) {
+                    LOG.warn("** Deposit Services was compiled from a Git repository with uncommitted changes! **");
+                }
+            } catch (IOException e) {
+                LOG.warn("Starting DepositService (" + GIT_PROPERTIES_RESOURCE_PATH + " could not be parsed: " + e.getMessage() + ")");
             }
         }
     }

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/DepositApp.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/DepositApp.java
@@ -248,7 +248,7 @@ public class DepositApp {
 
         boolean defaultAdditivity = false;
         String defaultAppender = "STDERR";
-        String rootLoggerName = "ROOT";
+        String rootLoggerName = org.slf4j.Logger.ROOT_LOGGER_NAME;
 
         // Update existing loggers, or add new loggers if they don't exist
         logMerged.forEach((loggerName, level) -> {

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositTaskHelper.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositTaskHelper.java
@@ -366,7 +366,7 @@ public class DepositTaskHelper {
 
                     switch (status.get()) {
                         case ACCEPTED: {
-                            LOG.debug("Deposit {} was accepted.", deposit.getId());
+                            LOG.info("Deposit {} was accepted.", deposit.getId());
                             deposit.setDepositStatus(ACCEPTED);
                             repoCopy.setCopyStatus(RepositoryCopy.CopyStatus.COMPLETE);
                             repoCopy = passClient.updateAndReadResource(repoCopy, RepositoryCopy.class);
@@ -374,7 +374,7 @@ public class DepositTaskHelper {
                         }
 
                         case REJECTED: {
-                            LOG.debug("Deposit {} was rejected.", deposit.getId());
+                            LOG.info("Deposit {} was rejected.", deposit.getId());
                             deposit.setDepositStatus(Deposit.DepositStatus.REJECTED);
                             repoCopy.setCopyStatus(RepositoryCopy.CopyStatus.REJECTED);
                             repoCopy = passClient.updateAndReadResource(repoCopy, RepositoryCopy.class);


### PR DESCRIPTION
Upon startup Deposit Services will evaluate environment variables or system properties in the form of `PASS_DEPOSIT_LOG_<logger name>=<LEVEL>` or `pass.deposit.log.<logger name>=<LEVEL>`, respectively.

Accepted values of `<LEVEL>` are:
* `ALL`
* `OFF`
* `ERROR`
* `WARN`
* `INFO`
* `DEBUG`
* `TRACE`

Accepted values of `<logger name>` are any name that would be used to instantiate an SLF4J `Logger` instance or designate a package-level log level; typically a package name or a class name:
* `org.dataconservancy.pass.deposit`
* `org.dataconservancy.pass.deposit.messaging.service.DepositProcessor`

If a `<logger>` definition already exists in `logback.xml` for a given `<logger name>`, the `Logger` is simply updated to the new log level.  If no `<logger>` definition exists for a given `<logger name>`, Deposit Services will create a new `Logger`, with `additivity` equal to `false`, and use the `STDERR` appender (defined in `logback.xml`) for its appender.

*N.B.*: updates `logback-classic` to a compile-time dependency instead of a runtime dependency.