### PR TITLE
Account for RepositoryCopy resources created for mediated DSpace deposits

### DIFF
--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositTask.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositTask.java
@@ -324,9 +324,7 @@ public class DepositTask implements Runnable {
                 // Deposit resource that is updated by the updateResources(...) method
                 dc.deposit(criDeposit);
                 return dc.deposit().getDepositStatusRef() != null &&
-                        dc.repoCopy() != null &&
-                        !dc.repoCopy().getExternalIds().isEmpty() &&
-                        dc.repoCopy().getAccessUrl() != null;
+                        dc.repoCopy() != null;
             };
         }
 


### PR DESCRIPTION
Mediated deposits to DSpace won't have an Item URL yet, so the RepositoryCopy won't have external ids or access urls.