### PR TITLE
Refactor AtomFeedStatusResolver to support redirects from http to https URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The primary mechanism for configuring Deposit Services is through environment va
 |`PASS_DEPOSIT_QUEUE_DEPOSIT_NAME`              |deposit                                                                        |the name of the JMS queue that has messages pertaining to `Deposit` resources (used by the `JmsDepositProcessor`)
 |`PASS_DEPOSIT_REPOSITORY_CONFIGURATION`         |classpath:/repositories.json                                                  |points to a properties file containing the configuration for the transport of custodial content to remote repositories.  Values must be [Spring Resource URIs][1].  See below for customizing the repository configuration values.
 |`PASS_DEPOSIT_TRANSPORT_SWORDV2_SLEEP_TIME_MS` |10000                                                                          |the number of milliseconds to wait between depositing a package using SWORD, and checking the SWORD statement for the deposit state
+|`PASS_DEPOSIT_TRANSPORT_SWORDV2_FOLLOW_REDIRECTS`|false|Specifically controls whether or not the `AtomFeedStatusResolver` follows HTTP redirects or not
 |`PASS_DEPOSIT_WORKERS_CONCURRENCY`             |4                                                                              |the number of Deposit Worker threads that can simultaneously run.
 |`PASS_ELASTICSEARCH_LIMIT`                     |100                                                                            |the maximum number of results returned in a single search response
 |`PASS_ELASTICSEARCH_URL`                       |http://${es.host:localhost}:${es.port:9200}/pass                               |the URL used to communicate with the Elastic search API.  Normally this this variable does not need to be changed (see note below)
@@ -41,7 +42,6 @@ The primary mechanism for configuring Deposit Services is through environment va
 |`SPRING_ACTIVEMQ_PASSWORD`                     |`null`                                                                         |Password to use when authenticating to the broker
 |`SPRING_ACTIVEMQ_USER`                         |`null`                                                                         |User name to use when authenticating to the broker
 |`SPRING_JMS_LISTENER_CONCURRENCY`              |4                                                                              |the number of JMS messages that can be processed simultaneously by _each_ JMS queue
-|`PASS_DEPOSIT_FOLLOW_REDIRECTS`|false|Specifically controls whether or not the `AutheticatedResource` follows HTTP redirects or not
 
 > If the Fedora repository is deployed under a webapp context other than `/fcrepo`, or if `https` ought to be used instead of `http`, the environment variable `PASS_FEDORA_BASEURL` must be set to the base of the Fedora REST API (e.g. `PASS_FEDORA_BASEURL=https://fcrepo:8080/rest`)
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The primary mechanism for configuring Deposit Services is through environment va
 |`SPRING_ACTIVEMQ_PASSWORD`                     |`null`                                                                         |Password to use when authenticating to the broker
 |`SPRING_ACTIVEMQ_USER`                         |`null`                                                                         |User name to use when authenticating to the broker
 |`SPRING_JMS_LISTENER_CONCURRENCY`              |4                                                                              |the number of JMS messages that can be processed simultaneously by _each_ JMS queue
+|`PASS_DEPOSIT_FOLLOW_REDIRECTS`|false|Specifically controls whether or not the `AutheticatedResource` follows HTTP redirects or not
 
 > If the Fedora repository is deployed under a webapp context other than `/fcrepo`, or if `https` ought to be used instead of `http`, the environment variable `PASS_FEDORA_BASEURL` must be set to the base of the Fedora REST API (e.g. `PASS_FEDORA_BASEURL=https://fcrepo:8080/rest`)
 

--- a/deposit-messaging/pom.xml
+++ b/deposit-messaging/pom.xml
@@ -363,6 +363,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/spring/DepositConfig.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/spring/DepositConfig.java
@@ -107,12 +107,6 @@ public class DepositConfig {
     @Value("${pass.deposit.repository.configuration}")
     private Resource repositoryConfigResource;
 
-    @Value("${pass.deposit.transport.followRedirects}")
-    private boolean transportFollowsRedirects;
-
-    @Value("${pass.deposit.assembler.followRedirects}")
-    private boolean assemblerFollowsRedirects;
-
     @Bean
     public PassClientDefault passClient() {
 
@@ -361,7 +355,7 @@ public class DepositConfig {
     }
 
     @Bean
-    public AtomFeedStatusResolver atomFeedStatusParser(Parser abderaParser, @Value("${pass.deposit.transport.followRedirects}") boolean followRedirects) {
+    public AtomFeedStatusResolver atomFeedStatusParser(Parser abderaParser, @Value("${pass.deposit.transport.swordv2.followRedirects}") boolean followRedirects) {
         return new AtomFeedStatusResolver(abderaParser, followRedirects);
     }
 

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/spring/DepositConfig.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/spring/DepositConfig.java
@@ -41,6 +41,8 @@ import org.dataconservancy.pass.deposit.messaging.status.DefaultDepositStatusPro
 import org.dataconservancy.pass.deposit.messaging.status.DepositStatusProcessor;
 import org.dataconservancy.pass.deposit.messaging.status.DepositStatusResolver;
 import org.dataconservancy.pass.deposit.messaging.support.swordv2.AtomFeedStatusResolver;
+import org.dataconservancy.pass.deposit.messaging.support.swordv2.ResourceResolver;
+import org.dataconservancy.pass.deposit.messaging.support.swordv2.ResourceResolverImpl;
 import org.dataconservancy.pass.deposit.transport.Transport;
 import org.dataconservancy.pass.support.messaging.cri.CriticalRepositoryInteraction;
 import org.slf4j.Logger;
@@ -355,9 +357,15 @@ public class DepositConfig {
     }
 
     @Bean
-    public AtomFeedStatusResolver atomFeedStatusParser(Parser abderaParser, @Value("${pass.deposit.transport.swordv2.followRedirects}") boolean followRedirects) {
-        return new AtomFeedStatusResolver(abderaParser, followRedirects);
+    public AtomFeedStatusResolver atomFeedStatusParser(Parser abderaParser, ResourceResolver resourceResolver) {
+        return new AtomFeedStatusResolver(abderaParser, resourceResolver);
     }
+
+    @Bean
+    public ResourceResolverImpl resourceResolver(@Value("${pass.deposit.transport.swordv2.followRedirects}") boolean followRedirects) {
+        return new ResourceResolverImpl(followRedirects);
+    }
+
 
     @Bean({"defaultDepositStatusProcessor", "org.dataconservancy.pass.deposit.messaging.status.DefaultDepositStatusProcessor"})
     public DefaultDepositStatusProcessor defaultDepositStatusProcessor(DepositStatusResolver<URI, URI> statusResolver) {

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/spring/DepositConfig.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/spring/DepositConfig.java
@@ -107,6 +107,12 @@ public class DepositConfig {
     @Value("${pass.deposit.repository.configuration}")
     private Resource repositoryConfigResource;
 
+    @Value("${pass.deposit.transport.followRedirects}")
+    private boolean transportFollowsRedirects;
+
+    @Value("${pass.deposit.assembler.followRedirects}")
+    private boolean assemblerFollowsRedirects;
+
     @Bean
     public PassClientDefault passClient() {
 
@@ -355,8 +361,8 @@ public class DepositConfig {
     }
 
     @Bean
-    public AtomFeedStatusResolver atomFeedStatusParser(Parser abderaParser) {
-        return new AtomFeedStatusResolver(abderaParser);
+    public AtomFeedStatusResolver atomFeedStatusParser(Parser abderaParser, @Value("${pass.deposit.transport.followRedirects}") boolean followRedirects) {
+        return new AtomFeedStatusResolver(abderaParser, followRedirects);
     }
 
     @Bean({"defaultDepositStatusProcessor", "org.dataconservancy.pass.deposit.messaging.status.DefaultDepositStatusProcessor"})

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/swordv2/AtomFeedStatusResolver.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/swordv2/AtomFeedStatusResolver.java
@@ -61,8 +61,15 @@ public class AtomFeedStatusResolver implements DepositStatusResolver<URI, URI> {
 
     private Parser abderaParser;
 
+    private boolean followRedirects;
+
     public AtomFeedStatusResolver(Parser abderaParser) {
+        this(abderaParser, false);
+    }
+
+    public AtomFeedStatusResolver(Parser abderaParser, boolean followRedirects) {
         this.abderaParser = abderaParser;
+        this.followRedirects = followRedirects;
     }
 
     /**

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/swordv2/AtomFeedStatusResolver.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/swordv2/AtomFeedStatusResolver.java
@@ -108,7 +108,7 @@ public class AtomFeedStatusResolver implements DepositStatusResolver<URI, URI> {
                             try {
                                 if (realm.getUsername() != null && realm.getUsername().trim().length() > 0) {
                                     return new AuthenticatedResource(atomStatementUri.toURL(),
-                                            realm.getUsername(), realm.getPassword());
+                                            realm.getUsername(), realm.getPassword(), followRedirects);
                                 } else {
                                     return new UrlResource(atomStatementUri.toURL());
                                 }

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/swordv2/AtomFeedStatusResolver.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/swordv2/AtomFeedStatusResolver.java
@@ -203,7 +203,9 @@ public class AtomFeedStatusResolver implements DepositStatusResolver<URI, URI> {
             int code = conn.getResponseCode();
             if (code >= 300 && code <= 307 && code != 306 &&
                     code != HttpURLConnection.HTTP_NOT_MODIFIED) {
-                return Optional.of(URI.create(conn.getHeaderField("Location")).toURL());
+                URL location = URI.create(conn.getHeaderField("Location")).toURL();
+                LOG.debug("{} will redirect {} to {}", AtomFeedStatusResolver.class.getSimpleName(), original, location);
+                return Optional.of(location);
             }
         } catch (IOException e) {
             LOG.warn("Unable to determine if {} would be redirected, an i/o error occurred", original, e);

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/swordv2/ResourceResolver.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/swordv2/ResourceResolver.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging.support.swordv2;
+
+import org.dataconservancy.pass.deposit.messaging.config.repository.RepositoryConfig;
+import org.springframework.core.io.Resource;
+
+import java.net.URI;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+@FunctionalInterface
+public interface ResourceResolver {
+
+    Resource resolve(URI uri, RepositoryConfig repositoryConfig);
+
+}

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/swordv2/ResourceResolverImpl.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/swordv2/ResourceResolverImpl.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2019 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging.support.swordv2;
+
+import org.dataconservancy.pass.deposit.assembler.shared.AuthenticatedResource;
+import org.dataconservancy.pass.deposit.messaging.config.repository.AuthRealm;
+import org.dataconservancy.pass.deposit.messaging.config.repository.BasicAuthRealm;
+import org.dataconservancy.pass.deposit.messaging.config.repository.RepositoryConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static org.dataconservancy.pass.deposit.messaging.support.swordv2.AtomFeedStatusResolver.ERR;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class ResourceResolverImpl implements ResourceResolver {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ResourceResolverImpl.class);
+
+    private boolean followRedirects;
+
+    public ResourceResolverImpl(boolean followRedirects) {
+        this.followRedirects = followRedirects;
+    }
+
+    @Override
+    public Resource resolve(URI uri, RepositoryConfig repositoryConfig) {
+        Resource resource = null;
+
+        if (uri.getScheme().startsWith("file")) {
+            resource = new FileSystemResource(uri.getPath());
+        } else if (uri.getScheme().startsWith("classpath")) {
+            if (uri.getScheme().startsWith("classpath*")) {
+                resource = new ClassPathResource(uri.toString().substring("classpath*:".length()));
+            } else {
+                resource = new ClassPathResource(uri.toString().substring("classpath:".length()));
+            }
+        } else if (uri.getScheme().startsWith("http")) {
+            resource = matchRealm(uri.toString(),
+                    repositoryConfig.getTransportConfig().getAuthRealms())
+                    .map(realm -> {
+                        try {
+                            if (realm.getUsername() != null && realm.getUsername().trim().length() > 0) {
+                                if (followRedirects) {
+                                    return new AuthenticatedResource(isRedirect(uri.toURL()).orElse(uri.toURL()),
+                                            realm.getUsername(), realm.getPassword());
+                                } else {
+                                    return new AuthenticatedResource(uri.toURL(),
+                                            realm.getUsername(), realm.getPassword());
+                                }
+                            } else {
+                                return new UrlResource(uri.toURL());
+                            }
+                        } catch (MalformedURLException e) {
+                            String msg = format(ERR, uri, "Statement URI could not be parsed as URL");
+                            throw new IllegalArgumentException(msg, e);
+                        }
+                    }).orElseGet(() -> {
+                        LOG.warn("Null AuthRealm used for Atom Statement URI '{}'", uri);
+                        try {
+                            return new UrlResource(uri.toURL());
+                        } catch (MalformedURLException e) {
+                            String msg = format(ERR, uri, "Statement URI could not be parsed as URL");
+                            throw new IllegalArgumentException(msg, e);
+                        }
+                    });
+        } else if (uri.getScheme().startsWith("jar")) {
+            try {
+                resource = new UrlResource(uri);
+            } catch (MalformedURLException e) {
+                String msg = format(ERR, uri, "Statement URI could not be parsed as URL");
+                throw new IllegalArgumentException(msg, e);
+            }
+        }
+
+        return resource;
+    }
+
+
+    private static Optional<BasicAuthRealm> matchRealm(String url, Collection<AuthRealm> authRealms) {
+        if (authRealms == null || authRealms.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return authRealms
+                .stream()
+                .filter(realm -> realm instanceof BasicAuthRealm)
+                .map(realm -> (BasicAuthRealm) realm)
+                .filter(realm -> url.startsWith(realm.getBaseUrl().toString()))
+                .max(Comparator.comparingInt(realm -> realm.getBaseUrl().length()));
+    }
+
+    /**
+     * Determines if the supplied URI will be redirected when opened, returning the redirect URL if so.
+     * <p>
+     * Returns an empty Optional if the scheme is not http or https.
+     * Performs a HEAD request on the original URI.
+     * If the response is 300, 301, 302, 303, 305, or 307 (<em>not</em> 306 or 304), the value of the Location header is
+     * returned as a URL.
+     * Otherwise an empty Optional is returned.
+     * If any exceptions occur, they are swallowed and logged at WARN level, and an empty Optional is returned.
+     * </p>
+     *
+     * @param original the URI, which may be of any scheme.
+     * @return an Optional containing the redirect URL, or an empty Optional if the original URI is not redirected
+     */
+    static Optional<URL> isRedirect(URL original) {
+        if (!"https".equalsIgnoreCase(original.getProtocol()) && !"http".equalsIgnoreCase(original.getProtocol())) {
+            return Optional.empty();
+        }
+
+        HttpURLConnection conn = null;
+        try {
+            conn = (HttpURLConnection)original.openConnection();
+        } catch (IOException e) {
+            LOG.warn("Unable to determine if {} would be redirected, connection could not be opened.", original, e);
+            return Optional.empty();
+        }
+
+        try {
+            conn.setRequestMethod("HEAD");
+            int code = conn.getResponseCode();
+            if (code >= 300 && code <= 307 && code != 306 &&
+                    code != HttpURLConnection.HTTP_NOT_MODIFIED) {
+                URL location = URI.create(conn.getHeaderField("Location")).toURL();
+                LOG.debug("{} will redirect {} to {}", AtomFeedStatusResolver.class.getSimpleName(), original, location);
+                return Optional.of(location);
+            }
+        } catch (IOException e) {
+            LOG.warn("Unable to determine if {} would be redirected, an i/o error occurred", original, e);
+        } finally {
+            conn.disconnect();
+        }
+
+        return Optional.empty();
+    }
+}

--- a/deposit-messaging/src/main/resources/application.properties
+++ b/deposit-messaging/src/main/resources/application.properties
@@ -37,6 +37,7 @@ pass.deposit.queue.deposit.name=deposit
 pass.deposit.queue.submission.name=submission
 # TODO probably should be configured on a repository-by-repository basis
 pass.deposit.transport.swordv2.sleep-time-ms=10000
+pass.deposit.transport.swordv2.followRedirects=false
 pass.deposit.jobs.disabled=false
 # By default run all jobs every 10 minutes
 pass.deposit.jobs.default-interval-ms=600000
@@ -44,7 +45,3 @@ pass.deposit.jobs.concurrency=2
 
 jscholarship.hack.sword.statement.uri-prefix=http://dspace-prod.mse.jhu.edu:8080/swordv2/
 jscholarship.hack.sword.statement.uri-replacement=https://jscholarship.library.jhu.edu/swordv2/
-
-pass.deposit.followRedirects=false
-pass.deposit.assembler.followRedirects=${pass.deposit.followRedirects:false}
-pass.deposit.transport.followRedirects=${pass.deposit.followRedirects:false}

--- a/deposit-messaging/src/main/resources/application.properties
+++ b/deposit-messaging/src/main/resources/application.properties
@@ -44,3 +44,7 @@ pass.deposit.jobs.concurrency=2
 
 jscholarship.hack.sword.statement.uri-prefix=http://dspace-prod.mse.jhu.edu:8080/swordv2/
 jscholarship.hack.sword.statement.uri-replacement=https://jscholarship.library.jhu.edu/swordv2/
+
+pass.deposit.followRedirects=false
+pass.deposit.assembler.followRedirects=${pass.deposit.followRedirects:false}
+pass.deposit.transport.followRedirects=${pass.deposit.followRedirects:false}

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/support/swordv2/AtomFeedStatusParserTest.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/support/swordv2/AtomFeedStatusParserTest.java
@@ -61,11 +61,14 @@ public class AtomFeedStatusParserTest {
 
     private AtomFeedStatusResolver underTest;
 
+    private ResourceResolver resourceResolver;
+
     @Before
     public void setUp() throws Exception {
         abderaParser = mock(Parser.class);
         repositoryConfig = mock(RepositoryConfig.class);
-        underTest = new AtomFeedStatusResolver(abderaParser);
+        resourceResolver = mock(ResourceResolver.class);
+        underTest = new AtomFeedStatusResolver(abderaParser, resourceResolver);
     }
 
     // Test cases

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/support/swordv2/AtomFeedStatusParserTest.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/support/swordv2/AtomFeedStatusParserTest.java
@@ -24,6 +24,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.springframework.core.io.Resource;
 
 import java.io.InputStream;
 import java.net.URI;
@@ -35,6 +36,7 @@ import static org.dataconservancy.pass.deposit.messaging.status.SwordDspaceDepos
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.dataconservancy.pass.deposit.messaging.support.swordv2.AtomResources.ARCHIVED_STATUS_RESOURCE;
@@ -130,25 +132,38 @@ public class AtomFeedStatusParserTest {
 
     @Test
     public void parseWithRuntimeException() throws Exception {
+        URI uri = findUriByName(ARCHIVED_STATUS_RESOURCE, AtomResources.class);
+
+        Resource resource = mock(Resource.class);
+        when(resource.getInputStream()).thenReturn(mock(InputStream.class));
+
         RuntimeException expected = new RuntimeException("Expected exception.");
         expectedException.expect(RuntimeException.class);
         expectedException.expectMessage("Expected exception.");
         expectedException.expectMessage("AtomStatusParser-archived.xml");
+
+        when(resourceResolver.resolve(eq(uri), any(RepositoryConfig.class))).thenReturn(resource);
         when(abderaParser.parse(any(InputStream.class))).thenThrow(expected);
 
-        underTest.resolve(findUriByName(ARCHIVED_STATUS_RESOURCE, AtomResources.class), repositoryConfig);
+        underTest.resolve(uri, repositoryConfig);
     }
 
     @Test
     public void parseWithParseException() throws Exception {
+        URI uri = findUriByName(ARCHIVED_STATUS_RESOURCE, AtomResources.class);
+
+        Resource resource = mock(Resource.class);
+        when(resource.getInputStream()).thenReturn(mock(InputStream.class));
+
         ParseException expectedCause = new ParseException("Expected cause.");
         expectedException.expect(RuntimeException.class);
         expectedException.expectCause(is(expectedCause));
         expectedException.expectMessage("Expected cause.");
         expectedException.expectMessage("AtomStatusParser-archived.xml");
 
+        when(resourceResolver.resolve(eq(uri), any(RepositoryConfig.class))).thenReturn(resource);
         when(abderaParser.parse(any(InputStream.class))).thenThrow(expectedCause);
 
-        underTest.resolve(findUriByName(ARCHIVED_STATUS_RESOURCE, AtomResources.class), repositoryConfig);
+        underTest.resolve(uri, repositoryConfig);
     }
 }

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/support/swordv2/AtomFeedStatusResolverTest.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/support/swordv2/AtomFeedStatusResolverTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging.support.swordv2;
+
+import org.apache.abdera.parser.Parser;
+import org.apache.abdera.parser.stax.FOMParserFactory;
+import org.dataconservancy.pass.deposit.messaging.config.repository.RepositoryConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.io.Resource;
+
+import java.io.InputStream;
+import java.net.URI;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class AtomFeedStatusResolverTest {
+
+    private Parser abdera;
+
+    private ResourceResolver resolver;
+
+    private AtomFeedStatusResolver underTest;
+
+    private Resource resource;
+
+    @Before
+    public void setUp() throws Exception {
+        abdera = new FOMParserFactory().getParser();
+        resolver = mock(ResourceResolver.class);
+        resource = mock(Resource.class);
+
+        when(resolver.resolve(any(), any())).thenReturn(resource);
+        InputStream swordStatement = this.getClass().getResourceAsStream("/org/dataconservancy/pass/deposit/messaging/support/swordv2/sword-statement.xml");
+        assertNotNull(swordStatement);
+        when(resource.getInputStream()).thenReturn(swordStatement);
+
+        underTest = new AtomFeedStatusResolver(abdera, resolver);
+    }
+
+    @Test
+    public void parseOk() {
+        URI status = underTest.resolve(URI.create("http://moo"), new RepositoryConfig());
+        assertNotNull(status);
+        assertEquals("http://dspace.org/state/inreview", status.toString());
+    }
+}

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/support/swordv2/ResourceResolverImplTest.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/support/swordv2/ResourceResolverImplTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2019 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging.support.swordv2;
+
+import org.dataconservancy.pass.deposit.assembler.shared.AuthenticatedResource;
+import org.dataconservancy.pass.deposit.messaging.config.repository.BasicAuthRealm;
+import org.dataconservancy.pass.deposit.messaging.config.repository.RepositoryConfig;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.dataconservancy.pass.deposit.messaging.support.swordv2.ResourceResolverImpl.isRedirect;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class ResourceResolverImplTest {
+
+    private RepositoryConfig repoConfig;
+
+    private URI uri;
+
+    private URL url;
+
+    private String originalUri;
+
+    private String redirectUrl;
+
+    private HttpURLConnection conn;
+
+    private ResourceResolverImpl redirectingResolver;
+
+    private ResourceResolverImpl resolver;
+
+    @Before
+    public void setUp() throws Exception {
+        repoConfig = mock(RepositoryConfig.class, RETURNS_DEEP_STUBS);
+        url = mock(URL.class);
+        uri = mock(URI.class);
+        originalUri = "http://some/url";
+
+        redirectUrl = "https://some/url";
+        conn = mock(HttpURLConnection.class);
+
+        when(uri.toURL()).thenReturn(url);
+        when(uri.toString()).thenReturn(originalUri);
+        when(uri.getScheme()).thenReturn("http");
+        when(uri.toString()).thenReturn(originalUri);
+
+        when(url.getProtocol()).thenReturn("http");
+        when(url.openConnection()).thenReturn(conn);
+        when(url.toString()).thenReturn(originalUri);
+
+        when(conn.getResponseCode()).thenReturn(302);
+        when(conn.getHeaderField("Location")).thenReturn(redirectUrl);
+
+        BasicAuthRealm realm = mock(BasicAuthRealm.class);
+        when(repoConfig.getTransportConfig().getAuthRealms()).thenReturn(Collections.singletonList(realm));
+        when(realm.getUsername()).thenReturn("fedoraAdmin");
+        when(realm.getPassword()).thenReturn("moo");
+        when(realm.getBaseUrl()).thenReturn(originalUri);
+
+        resolver = new ResourceResolverImpl(false);
+
+        redirectingResolver = new ResourceResolverImpl(true);
+    }
+
+    @Test
+    public void resolveWithRedirect() throws IOException {
+        Resource r = redirectingResolver.resolve(uri, repoConfig);
+
+        assertNotNull(r);
+        assertEquals(AuthenticatedResource.class, r.getClass());
+
+        assertEquals(redirectUrl, r.getURL().toString());
+
+        verify(conn).getResponseCode();
+        verify(conn).getHeaderField("Location");
+    }
+
+    @Test
+    public void resolveNoRedirect() throws IOException {
+        Resource r = resolver.resolve(uri, repoConfig);
+
+        assertNotNull(r);
+        assertEquals(AuthenticatedResource.class, r.getClass());
+
+        assertEquals(originalUri, r.getURL().toString());
+
+        verifyNoInteractions(conn);
+    }
+
+    @Test
+    public void nonHttpOrHttpsUrl() throws MalformedURLException {
+        assertEquals(Optional.empty(), isRedirect(new URL("file:///foo/bar/baz")));
+        verifyNoInteractions(conn);
+    }
+
+    @Test
+    public void test302RedirectOk() throws IOException {
+        assertEquals(redirectUrl, isRedirect(url).get().toString());
+        verify(conn).getResponseCode();
+        verify(conn).getHeaderField("Location");
+    }
+
+    @Test
+    public void test306and304() throws IOException {
+        reset(conn);
+        when(conn.getResponseCode()).thenReturn(304);
+
+        assertEquals(Optional.empty(), isRedirect(url));
+        verify(conn).getResponseCode();
+        verify(conn, times(0)).getHeaderField("Location");
+
+        reset(conn);
+        when(conn.getResponseCode()).thenReturn(306);
+
+        assertEquals(Optional.empty(), isRedirect(url));
+        verify(conn).getResponseCode();
+        verify(conn, times(0)).getHeaderField("Location");
+    }
+
+    @Test
+    public void testNon3xx() throws IOException {
+        reset(conn);
+        when(conn.getResponseCode()).thenReturn(400);
+
+        assertEquals(Optional.empty(), isRedirect(url));
+        verify(conn).getResponseCode();
+        verify(conn, times(0)).getHeaderField("Location");
+
+        reset(conn);
+        when(conn.getResponseCode()).thenReturn(500);
+
+        assertEquals(Optional.empty(), isRedirect(url));
+        verify(conn).getResponseCode();
+        verify(conn, times(0)).getHeaderField("Location");
+
+        reset(conn);
+        when(conn.getResponseCode()).thenReturn(200);
+
+        assertEquals(Optional.empty(), isRedirect(url));
+        verify(conn).getResponseCode();
+        verify(conn, times(0)).getHeaderField("Location");
+    }
+
+    @Test
+    public void withClasspathUri() {
+        URI uri = URI.create("classpath:/path/to/resource");
+        Resource resource = resolver.resolve(uri, repoConfig);
+        assertEquals(ClassPathResource.class, resource.getClass());
+    }
+
+    @Test
+    @Ignore("Can't be done, '*' is an illegal character for a URI scheme")
+    public void withClasspathStarUri() {
+        URI uri = URI.create("classpath*:/path/to/resource");
+        Resource resource = resolver.resolve(uri, repoConfig);
+        assertEquals(ClassPathResource.class, resource.getClass());
+    }
+
+    @Test
+    public void withFileUri() {
+        URI uri = URI.create("file:/path/to/resource");
+        Resource resource = resolver.resolve(uri, repoConfig);
+        assertEquals(FileSystemResource.class, resource.getClass());
+    }
+
+    @Test
+    public void withHttpUri() {
+        URI uri = URI.create("http://path/to/resource");
+        Resource resource = resolver.resolve(uri, repoConfig);
+        assertEquals(UrlResource.class, resource.getClass());
+        assertNotEquals(AuthenticatedResource.class, resource.getClass());
+    }
+
+    @Test
+    public void withHttpsUri() {
+        URI uri = URI.create("https://path/to/resource");
+        Resource resource = resolver.resolve(uri, repoConfig);
+        assertEquals(UrlResource.class, resource.getClass());
+        assertNotEquals(AuthenticatedResource.class, resource.getClass());
+    }
+
+    @Test
+    public void withHttpUriMatchingAuthRealm() {
+        URI uri = URI.create(originalUri);
+        Resource resource = resolver.resolve(uri, repoConfig);
+        assertEquals(AuthenticatedResource.class, resource.getClass());
+        assertNotEquals(UrlResource.class, resource.getClass());
+    }
+
+    @Test
+    public void withJarUri() {
+        URI uri = URI.create("jar:file:/path/to/file.jar!/path/to/resource");
+        Resource resource = resolver.resolve(uri, repoConfig);
+        assertEquals(UrlResource.class, resource.getClass());
+    }
+
+    @Test
+    public void withUnknownScheme() {
+        URI uri = URI.create("moo:/path/to/resource");
+        Resource resource = resolver.resolve(uri, repoConfig);
+        assertNull(resource);
+    }
+}

--- a/deposit-messaging/src/test/resources/org/dataconservancy/pass/deposit/messaging/support/swordv2/sword-statement.xml
+++ b/deposit-messaging/src/test/resources/org/dataconservancy/pass/deposit/messaging/support/swordv2/sword-statement.xml
@@ -1,0 +1,47 @@
+<!--
+  ~ Copyright 2019 Johns Hopkins University
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>http://dspace6-qa.lib.harvard.edu/swordv2/statement/53c55fab-6a3d-4d01-8853-c558f52ee8f2.atom</id>
+  <link href="http://dspace6-qa.lib.harvard.edu/swordv2/statement/53c55fab-6a3d-4d01-8853-c558f52ee8f2.atom" rel="self"/>
+  <title type="text">asfqewr</title>
+  <author>
+    <name>sdfgsdfg</name>
+  </author>
+  <updated>2019-11-14T15:33:03.000Z</updated>
+  <entry>
+    <content type="image/jpeg" src="http://dspace6-qa.lib.harvard.edu/swordv2/edit-media/bitstream/90faab3c-1ddc-4d1a-8d68-7363d6671ca1/data/loggins.jpg"/>
+    <id>http://dspace6-qa.lib.harvard.edu/swordv2/edit-media/bitstream/90faab3c-1ddc-4d1a-8d68-7363d6671ca1/data/loggins.jpg</id>
+    <title type="text">Resource http://dspace6-qa.lib.harvard.edu/swordv2/edit-media/bitstream/90faab3c-1ddc-4d1a-8d68-7363d6671ca1/data/loggins.jpg</title>
+    <summary type="text">Resource Part</summary>
+    <updated>2019-11-14T20:34:16.350Z</updated>
+  </entry>
+  <entry>
+    <content type="text/plain" src="http://dspace6-qa.lib.harvard.edu/swordv2/edit-media/bitstream/83ab5be2-9926-4a21-83c5-620f7e930765/license.txt"/>
+    <id>http://dspace6-qa.lib.harvard.edu/swordv2/edit-media/bitstream/83ab5be2-9926-4a21-83c5-620f7e930765/license.txt</id>
+    <title type="text">Resource http://dspace6-qa.lib.harvard.edu/swordv2/edit-media/bitstream/83ab5be2-9926-4a21-83c5-620f7e930765/license.txt</title>
+    <summary type="text">Resource Part</summary>
+    <updated>2019-11-14T20:34:16.350Z</updated>
+  </entry>
+  <entry>
+    <id>https://dspace6-qa.lib.harvard.edu/retrieve/04fe2ea3-046c-432e-a1ba-5e387b3b8d99/http:%2F%2Ffcrepo:8080%2Ffcrepo%2Frest%2Fsubmissions%2F95%2Fc6%2F06%2F8f%2F95c6068f-f79a-45fc-a182-38da146f53e1</id>
+    <title type="text">Original Deposit https://dspace6-qa.lib.harvard.edu/retrieve/04fe2ea3-046c-432e-a1ba-5e387b3b8d99/http:%2F%2Ffcrepo:8080%2Ffcrepo%2Frest%2Fsubmissions%2F95%2Fc6%2F06%2F8f%2F95c6068f-f79a-45fc-a182-38da146f53e1</title>
+    <summary type="text">Original Deposit</summary>
+    <updated>2019-11-14T20:34:16.350Z</updated>
+    <content type="application/octet-stream" src="https://dspace6-qa.lib.harvard.edu/retrieve/04fe2ea3-046c-432e-a1ba-5e387b3b8d99/http:%2F%2Ffcrepo:8080%2Ffcrepo%2Frest%2Fsubmissions%2F95%2Fc6%2F06%2F8f%2F95c6068f-f79a-45fc-a182-38da146f53e1"/>
+    <category term="http://purl.org/net/sword/terms/originalDeposit" scheme="http://purl.org/net/sword/terms/" label="Original Deposit"/>
+  </entry>
+  <category term="http://dspace.org/state/inreview" scheme="http://purl.org/net/sword/terms/state" label="State">The item is undergoing review prior to acceptance to the archive</category>
+</feed>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <commons-net.version>3.6</commons-net.version>
         <commons-compress.version>1.15</commons-compress.version>
         <commons-io.version>2.6</commons-io.version>
-        <mockito.version>2.24.5</mockito.version>
+        <mockito.version>3.1.0</mockito.version>
         <okhttp.version>3.10.0</okhttp.version>
         <guava.version>23.5-jre</guava.version>
         <args4j.version>2.33</args4j.version>
@@ -491,6 +491,12 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-inline</artifactId>
                 <version>${mockito.version}</version>
             </dependency>
 

--- a/shared-assembler/pom.xml
+++ b/shared-assembler/pom.xml
@@ -145,6 +145,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AbstractAssembler.java
+++ b/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AbstractAssembler.java
@@ -76,6 +76,8 @@ public abstract class AbstractAssembler implements Assembler {
 
     private String fedoraPassword;
 
+    private boolean followRedirects;
+
     /**
      * Constructs a new assembler that provides {@link MetadataBuilderFactory} and {@link ResourceBuilderFactory} for
      * implementations to create and amend the state of package metadata and resources.
@@ -238,7 +240,7 @@ public abstract class AbstractAssembler implements Assembler {
                         if (fedoraUser != null) {
                             try {
                                 LOG.trace("Returning AuthenticatedResource for {}", location);
-                                delegateResource = new AuthenticatedResource(new URL(location), fedoraUser, fedoraPassword);
+                                delegateResource = new AuthenticatedResource(new URL(location), fedoraUser, fedoraPassword, followRedirects);
                             } catch (MalformedURLException e) {
                                 throw new RuntimeException(e.getMessage(), e);
                             }
@@ -315,4 +317,12 @@ public abstract class AbstractAssembler implements Assembler {
         this.fedoraPassword = fedoraPassword;
     }
 
+    public boolean isFollowRedirects() {
+        return followRedirects;
+    }
+
+    @Value("${pass.deposit.assembler.followRedirects}")
+    public void setFollowRedirects(boolean followRedirects) {
+        this.followRedirects = followRedirects;
+    }
 }

--- a/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AbstractAssembler.java
+++ b/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AbstractAssembler.java
@@ -240,7 +240,7 @@ public abstract class AbstractAssembler implements Assembler {
                         if (fedoraUser != null) {
                             try {
                                 LOG.trace("Returning AuthenticatedResource for {}", location);
-                                delegateResource = new AuthenticatedResource(new URL(location), fedoraUser, fedoraPassword, followRedirects);
+                                delegateResource = new AuthenticatedResource(new URL(location), fedoraUser, fedoraPassword);
                             } catch (MalformedURLException e) {
                                 throw new RuntimeException(e.getMessage(), e);
                             }
@@ -317,12 +317,4 @@ public abstract class AbstractAssembler implements Assembler {
         this.fedoraPassword = fedoraPassword;
     }
 
-    public boolean isFollowRedirects() {
-        return followRedirects;
-    }
-
-    @Value("${pass.deposit.assembler.followRedirects}")
-    public void setFollowRedirects(boolean followRedirects) {
-        this.followRedirects = followRedirects;
-    }
 }

--- a/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AuthenticatedResource.java
+++ b/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AuthenticatedResource.java
@@ -43,11 +43,35 @@ public class AuthenticatedResource extends UrlResource {
 
     private String password;
 
+    private boolean followRedirects;
+
+    /**
+     * Preemptively supplies Basic authentication credentials when the URL is accessed.  Redirects are not followed
+     * when accessing the URL.
+     *
+     * @param url the URL of the resource requiring authentication
+     * @param username the username used to authenticate to the resource, may be empty or {@code null}
+     * @param password the password used to authenticate to the resource, may be empty or {@code null}
+     */
     public AuthenticatedResource(URL url, String username, String password) {
+        this(url, username, password, false);
+    }
+
+    /**
+     * Preemptively supplies Basic authentication credentials when the URL is accessed.  Redirects are followed if
+     * {@code followRedirects} is {@code true}.
+     *
+     * @param url the URL of the resource requiring authentication
+     * @param username the username used to authenticate to the resource, may be empty or {@code null}
+     * @param password the password used to authenticate to the resource, may be empty or {@code null}
+     * @param followRedirects follow redirects when {@code true}
+     */
+    public AuthenticatedResource(URL url, String username, String password, boolean followRedirects) {
         super(url);
         this.url = url;
         this.username = username;
         this.password = password;
+        this.followRedirects = followRedirects;
     }
 
     @Override
@@ -72,6 +96,7 @@ public class AuthenticatedResource extends UrlResource {
         LOG.trace("Customizing {}@{}", con.getClass().getName(), toHexString(identityHashCode(con)));
         byte[] bytes = String.format("%s:%s", username, password).getBytes();
         con.setRequestProperty("Authorization", "Basic " + getEncoder().encodeToString(bytes));
+        con.setInstanceFollowRedirects(followRedirects);
     }
 
 }

--- a/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AuthenticatedResource.java
+++ b/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AuthenticatedResource.java
@@ -43,8 +43,6 @@ public class AuthenticatedResource extends UrlResource {
 
     private String password;
 
-    private boolean followRedirects;
-
     /**
      * Preemptively supplies Basic authentication credentials when the URL is accessed.  Redirects are not followed
      * when accessing the URL.
@@ -54,24 +52,10 @@ public class AuthenticatedResource extends UrlResource {
      * @param password the password used to authenticate to the resource, may be empty or {@code null}
      */
     public AuthenticatedResource(URL url, String username, String password) {
-        this(url, username, password, false);
-    }
-
-    /**
-     * Preemptively supplies Basic authentication credentials when the URL is accessed.  Redirects are followed if
-     * {@code followRedirects} is {@code true}.
-     *
-     * @param url the URL of the resource requiring authentication
-     * @param username the username used to authenticate to the resource, may be empty or {@code null}
-     * @param password the password used to authenticate to the resource, may be empty or {@code null}
-     * @param followRedirects follow redirects when {@code true}
-     */
-    public AuthenticatedResource(URL url, String username, String password, boolean followRedirects) {
         super(url);
         this.url = url;
         this.username = username;
         this.password = password;
-        this.followRedirects = followRedirects;
     }
 
     @Override
@@ -96,7 +80,6 @@ public class AuthenticatedResource extends UrlResource {
         LOG.trace("Customizing {}@{}", con.getClass().getName(), toHexString(identityHashCode(con)));
         byte[] bytes = String.format("%s:%s", username, password).getBytes();
         con.setRequestProperty("Authorization", "Basic " + getEncoder().encodeToString(bytes));
-        con.setInstanceFollowRedirects(followRedirects);
     }
 
 }

--- a/shared-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/shared/AuthenticatedResourceTest.java
+++ b/shared-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/shared/AuthenticatedResourceTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2019 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.pass.deposit.assembler.shared;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import static java.util.Base64.getEncoder;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AuthenticatedResourceTest {
+
+    private URL resourceUrl;
+
+    private HttpURLConnection urlConn;
+
+    private InputStream in;
+
+    private String user = "cow";
+
+    private String pass = "moo";
+
+    private AuthenticatedResource underTest;
+
+    @Before
+    public void setUp() throws Exception {
+        resourceUrl = mock(URL.class);
+        in = mock(InputStream.class);
+        urlConn = mock(HttpURLConnection.class);
+
+        when(resourceUrl.openConnection()).thenReturn(urlConn);
+        when(urlConn.getInputStream()).thenReturn(in);
+
+        underTest = new AuthenticatedResource(resourceUrl, user, pass, true);
+    }
+
+    /**
+     * User and password on the AuthenticatedResource should be supplied as Basic auth
+     */
+    @Test
+    public void customizeConnBasicAuth() throws IOException {
+        underTest.getInputStream();
+        assertTrue(user.trim().length() > 0);
+        assertTrue(pass.trim().length() > 0);
+        verify(urlConn).setRequestProperty(eq("Authorization"), anyString());
+    }
+
+    /**
+     * null strings are allowed as a user name and password
+     */
+    @Test
+    public void customConnBasicAuthNullUserAndPass() throws IOException {
+        underTest = new AuthenticatedResource(resourceUrl, null, null);
+        underTest.getInputStream();
+        verify(urlConn).setRequestProperty(eq("Authorization"),
+                eq("Basic " + getEncoder().encodeToString(String.format("%s:%s", null, null).getBytes())));
+    }
+
+    /**
+     * Empty strings are allowed as a user name and password
+     */
+    @Test
+    public void customConnBasicAuthEmptyUserAndPass() throws IOException {
+        underTest = new AuthenticatedResource(resourceUrl, "", "");
+        underTest.getInputStream();
+        verify(urlConn).setRequestProperty(eq("Authorization"),
+                eq("Basic " + getEncoder().encodeToString(":".getBytes())));
+    }
+
+    /**
+     * Redirect flag ought to be set to true on the underlying URLConnection instance
+     */
+    @Test
+    public void customizeConnRedirect() throws IOException {
+        underTest.getInputStream();
+        verify(urlConn).setInstanceFollowRedirects(true);
+    }
+
+    /**
+     * Redirect flag ought to be false on the underlying URLConnection instance
+     */
+    @Test
+    public void customizeConnRedirectFalseWithConstructor() throws IOException {
+        underTest = new AuthenticatedResource(resourceUrl, "", "", false);
+        underTest.getInputStream();
+        verify(urlConn).setInstanceFollowRedirects(false);
+    }
+
+    /**
+     * Using the existing constructor for AuthenticatedResource preserves existing behavior (redirects are not followed)
+     */
+    @Test
+    public void existingRedirectBehavior() throws IOException {
+        underTest = new AuthenticatedResource(resourceUrl, "", "");
+        underTest.getInputStream();
+
+        verify(urlConn).setInstanceFollowRedirects(false);
+    }
+}

--- a/shared-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/shared/AuthenticatedResourceTest.java
+++ b/shared-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/shared/AuthenticatedResourceTest.java
@@ -55,7 +55,7 @@ public class AuthenticatedResourceTest {
         when(resourceUrl.openConnection()).thenReturn(urlConn);
         when(urlConn.getInputStream()).thenReturn(in);
 
-        underTest = new AuthenticatedResource(resourceUrl, user, pass, true);
+        underTest = new AuthenticatedResource(resourceUrl, user, pass);
     }
 
     /**
@@ -89,35 +89,5 @@ public class AuthenticatedResourceTest {
         underTest.getInputStream();
         verify(urlConn).setRequestProperty(eq("Authorization"),
                 eq("Basic " + getEncoder().encodeToString(":".getBytes())));
-    }
-
-    /**
-     * Redirect flag ought to be set to true on the underlying URLConnection instance
-     */
-    @Test
-    public void customizeConnRedirect() throws IOException {
-        underTest.getInputStream();
-        verify(urlConn).setInstanceFollowRedirects(true);
-    }
-
-    /**
-     * Redirect flag ought to be false on the underlying URLConnection instance
-     */
-    @Test
-    public void customizeConnRedirectFalseWithConstructor() throws IOException {
-        underTest = new AuthenticatedResource(resourceUrl, "", "", false);
-        underTest.getInputStream();
-        verify(urlConn).setInstanceFollowRedirects(false);
-    }
-
-    /**
-     * Using the existing constructor for AuthenticatedResource preserves existing behavior (redirects are not followed)
-     */
-    @Test
-    public void existingRedirectBehavior() throws IOException {
-        underTest = new AuthenticatedResource(resourceUrl, "", "");
-        underTest.getInputStream();
-
-        verify(urlConn).setInstanceFollowRedirects(false);
     }
 }


### PR DESCRIPTION
Allow redirect support to be enabled by the pass.deposit.followRedirects (or its PASS_DEPOSIT_FOLLOW_REDIRECTS equivalent).

Maintain existing behavior by defaulting pass.deposit.followRedirects to `false`.