### PR TITLE
WIP: Support for Submission.metadata collection hints (master)

### DIFF
--- a/assembler-api/src/main/java/org/dataconservancy/pass/deposit/assembler/MetadataBuilder.java
+++ b/assembler-api/src/main/java/org/dataconservancy/pass/deposit/assembler/MetadataBuilder.java
@@ -15,10 +15,9 @@
  */
 package org.dataconservancy.pass.deposit.assembler;
 
+import com.google.gson.JsonObject;
 import org.dataconservancy.pass.deposit.assembler.PackageOptions.Archive;
 import org.dataconservancy.pass.deposit.assembler.PackageOptions.Compression;
-
-import java.util.Map;
 
 /**
  * Allows for various components to contribute to the state of {@link PackageStream.Metadata} without the requirement to
@@ -122,7 +121,7 @@ public interface MetadataBuilder {
      * @return this builder
      * @see PackageStream.Metadata#submissionMeta()
      */
-    MetadataBuilder submissionMeta(Map<String, Object> meta);
+    MetadataBuilder submissionMeta(JsonObject meta);
 
     /**
      * Builds the Metadata object from the state set on this builder.

--- a/assembler-api/src/main/java/org/dataconservancy/pass/deposit/assembler/MetadataBuilder.java
+++ b/assembler-api/src/main/java/org/dataconservancy/pass/deposit/assembler/MetadataBuilder.java
@@ -18,6 +18,8 @@ package org.dataconservancy.pass.deposit.assembler;
 import org.dataconservancy.pass.deposit.assembler.PackageOptions.Archive;
 import org.dataconservancy.pass.deposit.assembler.PackageOptions.Compression;
 
+import java.util.Map;
+
 /**
  * Allows for various components to contribute to the state of {@link PackageStream.Metadata} without the requirement to
  * share knowledge of the underlying implementation.
@@ -112,6 +114,15 @@ public interface MetadataBuilder {
      * @see PackageStream.Metadata#checksum()
      */
     MetadataBuilder checksum(PackageStream.Checksum checksum);
+
+    /**
+     * Adds the metadata associated with the PASS Submission resource to the PackageStream.Metadata
+     *
+     * @param meta the {@code Submission.metadata} serialized as a map
+     * @return this builder
+     * @see PackageStream.Metadata#submissionMeta()
+     */
+    MetadataBuilder submissionMeta(Map<String, Object> meta);
 
     /**
      * Builds the Metadata object from the state set on this builder.

--- a/assembler-api/src/main/java/org/dataconservancy/pass/deposit/assembler/PackageStream.java
+++ b/assembler-api/src/main/java/org/dataconservancy/pass/deposit/assembler/PackageStream.java
@@ -15,6 +15,7 @@
  */
 package org.dataconservancy.pass.deposit.assembler;
 
+import com.google.gson.JsonObject;
 import org.dataconservancy.pass.deposit.assembler.PackageOptions.Archive;
 import org.dataconservancy.pass.deposit.assembler.PackageOptions.Compression;
 import org.dataconservancy.pass.deposit.model.DepositSubmission;
@@ -22,7 +23,6 @@ import org.dataconservancy.pass.deposit.model.DepositSubmission;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.Map;
 
 /**
  * A streamable serialized form of a submission package.
@@ -154,7 +154,7 @@ public interface PackageStream {
          *
          * @return the Submission metadata blob
          */
-        Map<String, Object> submissionMeta();
+        JsonObject submissionMeta();
 
     }
 

--- a/assembler-api/src/main/java/org/dataconservancy/pass/deposit/assembler/PackageStream.java
+++ b/assembler-api/src/main/java/org/dataconservancy/pass/deposit/assembler/PackageStream.java
@@ -22,6 +22,7 @@ import org.dataconservancy.pass.deposit.model.DepositSubmission;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Map;
 
 /**
  * A streamable serialized form of a submission package.
@@ -147,6 +148,13 @@ public interface PackageStream {
          * @return all available checksums
          */
         Collection<Checksum> checksums();
+
+        /**
+         * The {@code Submission.metadata} for this deposit, serialized as a Map.
+         *
+         * @return the Submission metadata blob
+         */
+        Map<String, Object> submissionMeta();
 
     }
 

--- a/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/builder/fedora/FcrepoModelBuilderIT.java
+++ b/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/builder/fedora/FcrepoModelBuilderIT.java
@@ -16,6 +16,7 @@
 
 package org.dataconservancy.pass.deposit.builder.fedora;
 
+import com.google.gson.JsonObject;
 import org.dataconservancy.pass.deposit.builder.fs.FcrepoModelBuilder;
 import org.dataconservancy.pass.deposit.builder.fs.PassJsonFedoraAdapter;
 import org.dataconservancy.pass.deposit.messaging.config.spring.DepositConfig;
@@ -119,6 +120,7 @@ public class FcrepoModelBuilderIT {
         assertNotNull(submission.getMetadata().getJournalMetadata());
         assertNotNull(submission.getMetadata().getArticleMetadata());
         assertNotNull(submission.getMetadata().getPersons());
+        assertNotNull(submission.getSubmissionMeta());
 
         // Cannot compare ID strings, as they change when uploading to a Fedora server.
         Publication publication = (Publication)entities.get(submissionEntity.getPublication());
@@ -188,6 +190,11 @@ public class FcrepoModelBuilderIT {
                 .filter(person -> person.getType() == DepositMetadata.PERSON_TYPE.author)
                 .anyMatch(author ->
                         author.getName().equals("Raymond J. Playford")));
+
+        // Read something out of the submission metadata
+        assertTrue(submission.getSubmissionMeta().has("agreement"));
+        JsonObject agreement = submission.getSubmissionMeta().getAsJsonObject("agreement");
+        assertTrue(agreement.has("JScholarship"));
     }
 
     @After

--- a/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/builder/fedora/FcrepoModelBuilderIT.java
+++ b/deposit-integration/src/test/java/org/dataconservancy/pass/deposit/builder/fedora/FcrepoModelBuilderIT.java
@@ -192,8 +192,8 @@ public class FcrepoModelBuilderIT {
                         author.getName().equals("Raymond J. Playford")));
 
         // Read something out of the submission metadata
-        assertTrue(submission.getSubmissionMeta().has("agreement"));
-        JsonObject agreement = submission.getSubmissionMeta().getAsJsonObject("agreement");
+        assertTrue(submission.getSubmissionMeta().has("agreements"));
+        JsonObject agreement = submission.getSubmissionMeta().getAsJsonObject("agreements");
         assertTrue(agreement.has("JScholarship"));
     }
 

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/repository/SwordV2Binding.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/repository/SwordV2Binding.java
@@ -17,12 +17,15 @@
 package org.dataconservancy.pass.deposit.messaging.config.repository;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.dataconservancy.pass.deposit.transport.Transport;
 import org.dataconservancy.pass.deposit.transport.sword2.Sword2TransportHints;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.StringJoiner;
 
 import static org.dataconservancy.pass.deposit.transport.Transport.TRANSPORT_AUTHMODE;
 import static org.dataconservancy.pass.deposit.transport.Transport.TRANSPORT_PASSWORD;
@@ -53,6 +56,9 @@ public class SwordV2Binding extends ProtocolBinding {
 
     @JsonProperty("user-agent")
     private String userAgent;
+
+    @JsonProperty("collection-hints")
+    private Map<String, String> collectionHints;
 
     public SwordV2Binding() {
         this.setProtocol(PROTO);
@@ -114,6 +120,36 @@ public class SwordV2Binding extends ProtocolBinding {
         this.userAgent = userAgent;
     }
 
+    public Map<String, String> getCollectionHints() {
+        return collectionHints;
+    }
+
+    public void setCollectionHints(Map<String, String> collectionHints) {
+        this.collectionHints = collectionHints;
+    }
+
+    /**
+     * Encodes the map of hints to SWORD collection urls as a string (to maintain compatibility with {@link
+     * #asPropertiesMap()}).  Note that any spaces in the urls *must* be properly encoded in the configuration file.
+     *
+     * @param collectionHints the map of collection hints
+     * @return a string encoding of those hints
+     */
+    String hintsToPropertyString(Map<String, String> collectionHints) {
+        if (collectionHints == null) {
+            return "";
+        }
+
+        StringJoiner joiner = new StringJoiner(Sword2TransportHints.HINT_TUPLE_SEPARATOR);
+        joiner.setEmptyValue("");
+
+        collectionHints.forEach((hint, url) -> {
+            joiner.add(hint.trim() + Sword2TransportHints.HINT_URL_SEPARATOR + url.trim());
+        });
+
+        return joiner.toString();
+    }
+
     @Override
     public Map<String, String> asPropertiesMap() {
         Map<String, String> transportProperties = new HashMap<>();
@@ -130,34 +166,33 @@ public class SwordV2Binding extends ProtocolBinding {
         transportProperties.put(Sword2TransportHints.SWORD_DEPOSIT_RECEIPT_FLAG, String.valueOf(isDepositReceipt()));
         transportProperties.put(Sword2TransportHints.SWORD_CLIENT_USER_AGENT, getUserAgent());
 
+        String collectionHints = hintsToPropertyString(this.collectionHints);
+        if (collectionHints != null && collectionHints.length() > 0) {
+            transportProperties.put(Sword2TransportHints.SWORD_COLLECTION_HINTS, collectionHints);
+        }
+
         return transportProperties;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        if (!super.equals(o))
+            return false;
         SwordV2Binding that = (SwordV2Binding) o;
-        return depositReceipt == that.depositReceipt &&
-                Objects.equals(username, that.username) &&
-                Objects.equals(password, that.password) &&
-                Objects.equals(serviceDocUrl, that.serviceDocUrl) &&
-                Objects.equals(defaultCollectionUrl, that.defaultCollectionUrl) &&
-                Objects.equals(onBehalfOf, that.onBehalfOf) &&
-                Objects.equals(userAgent, that.userAgent);
+        return depositReceipt == that.depositReceipt && Objects.equals(username, that.username) && Objects.equals(password, that.password) && Objects.equals(serviceDocUrl, that.serviceDocUrl) && Objects.equals(defaultCollectionUrl, that.defaultCollectionUrl) && Objects.equals(onBehalfOf, that.onBehalfOf) && Objects.equals(userAgent, that.userAgent) && Objects.equals(collectionHints, that.collectionHints);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), username, password, serviceDocUrl, defaultCollectionUrl, onBehalfOf, depositReceipt, userAgent);
+        return Objects.hash(super.hashCode(), username, password, serviceDocUrl, defaultCollectionUrl, onBehalfOf, depositReceipt, userAgent, collectionHints);
     }
 
     @Override
     public String toString() {
-        return "SwordV2Binding{" + "username='" + username + '\'' + ", password='" +
-                ((password != null) ? "xxxx" : "<null>" )+ '\'' + ", serviceDocUrl='" + serviceDocUrl + '\'' +
-                ", defaultCollectionUrl='" + defaultCollectionUrl + '\'' + ", onBehalfOf='" + onBehalfOf + '\'' +
-                ", depositReceipt=" + depositReceipt + ", userAgent='" + userAgent + '\'' + "} " + super.toString();
+        return new StringJoiner("\n  ", SwordV2Binding.class.getSimpleName() + "[", "]").add("username='" + username + "'").add("password='" + password + "'").add("serviceDocUrl='" + serviceDocUrl + "'").add("defaultCollectionUrl='" + defaultCollectionUrl + "'").add("onBehalfOf='" + onBehalfOf + "'").add("depositReceipt=" + depositReceipt).add("userAgent='" + userAgent + "'").add("collectionHints=" + collectionHints).toString();
     }
 }

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/config/repository/SwordV2BindingTest.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/config/repository/SwordV2BindingTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging.config.repository;
+
+import org.dataconservancy.pass.deposit.transport.sword2.Sword2TransportHints;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.dataconservancy.pass.deposit.transport.sword2.Sword2TransportHints.HINT_TUPLE_SEPARATOR;
+import static org.dataconservancy.pass.deposit.transport.sword2.Sword2TransportHints.HINT_URL_SEPARATOR;
+import static org.junit.Assert.*;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class SwordV2BindingTest {
+
+    private SwordV2Binding underTest;
+
+    @Before
+    public void setUp() throws Exception {
+        underTest = new SwordV2Binding();
+    }
+
+    @Test
+    public void hintsToPropertyString() {
+        String covid = "https://jscholarship.library.jhu.edu/handle/1774.2/58585";
+        String nobel = "https://jscholarship.library.jhu.edu/handle/1774.2/33532";
+        Map<String, String> hints = new HashMap<String, String>(){
+            {
+                put("covid", covid);
+                put("nobel", nobel);
+            }
+        };
+
+        String expected = "covid" + HINT_URL_SEPARATOR + covid + HINT_TUPLE_SEPARATOR +
+                "nobel" + HINT_URL_SEPARATOR + nobel;
+
+        assertEquals(expected, underTest.hintsToPropertyString(hints));
+        assertEquals(2, underTest.hintsToPropertyString(hints).split(" ").length);
+    }
+
+    @Test
+    public void hintsToPropertyStringTrailingOrLeadingSpace() {
+        String leading = " https://jscholarship.library.jhu.edu/handle/1774.2/58585";
+        String trailing = "https://jscholarship.library.jhu.edu/handle/1774.2/33532 ";
+        Map<String, String> hints = new HashMap<String, String>(){
+            {
+                put("covid", leading);
+                put("nobel", trailing);
+            }
+        };
+
+        String expected = "covid" + HINT_URL_SEPARATOR + leading.trim() + HINT_TUPLE_SEPARATOR +
+                "nobel" + HINT_URL_SEPARATOR + trailing.trim();
+
+        assertEquals(expected, underTest.hintsToPropertyString(hints));
+        assertEquals(2, underTest.hintsToPropertyString(hints).split(" ").length);
+    }
+
+    @Test
+    public void hintsToPropertyStringEncodedSpace() {
+        String encodedSpace = "https://jscholarship.library.jhu.edu/handle/1774.2/58585?moo=%20cow%20";
+        Map<String, String> hints = new HashMap<String, String>(){
+            {
+                put("covid", encodedSpace);
+            }
+        };
+
+        String expected = "covid" + HINT_URL_SEPARATOR + encodedSpace;
+
+        assertEquals(expected, underTest.hintsToPropertyString(hints));
+        assertEquals(1, underTest.hintsToPropertyString(hints).split(" ").length);
+    }
+
+    @Test
+    public void hintsToPropertyStringNullMap() {
+        assertEquals("", underTest.hintsToPropertyString(null));
+    }
+
+    @Test
+    public void hintsToPropertyStringEmptyMap() {
+        assertEquals("", underTest.hintsToPropertyString(Collections.emptyMap()));
+    }
+
+}

--- a/deposit-model/pom.xml
+++ b/deposit-model/pom.xml
@@ -32,6 +32,10 @@
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>
+      <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/deposit-model/src/main/java/org/dataconservancy/pass/deposit/model/DepositSubmission.java
+++ b/deposit-model/src/main/java/org/dataconservancy/pass/deposit/model/DepositSubmission.java
@@ -15,10 +15,10 @@
  */
 package org.dataconservancy.pass.deposit.model;
 
+import com.google.gson.JsonObject;
 import org.joda.time.DateTime;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
 
@@ -63,9 +63,9 @@ public class DepositSubmission {
     private String name;
 
     /**
-     * The PASS Submission.metadata serialized as a Map
+     * The PASS Submission.metadata serialized as a JsonObject
      */
-    private Map<String, Object> submissionMeta;
+    private JsonObject submissionMeta;
 
     public String getId() {
         return id;
@@ -125,11 +125,11 @@ public class DepositSubmission {
         this.submissionDate = submissionDate;
     }
 
-    public Map<String, Object> getSubmissionMeta() {
+    public JsonObject getSubmissionMeta() {
         return submissionMeta;
     }
 
-    public void setSubmissionMeta(Map<String, Object> submissionMeta) {
+    public void setSubmissionMeta(JsonObject submissionMeta) {
         this.submissionMeta = submissionMeta;
     }
 

--- a/deposit-model/src/main/java/org/dataconservancy/pass/deposit/model/DepositSubmission.java
+++ b/deposit-model/src/main/java/org/dataconservancy/pass/deposit/model/DepositSubmission.java
@@ -18,7 +18,9 @@ package org.dataconservancy.pass.deposit.model;
 import org.joda.time.DateTime;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.StringJoiner;
 
 /**
  * Encapsulates a submission to the target system, including the manuscript and supplement files, metadata describing
@@ -59,6 +61,11 @@ public class DepositSubmission {
      * Short, human-readable, name of the submission.  Used to generate the file name for the package file.
      */
     private String name;
+
+    /**
+     * The PASS Submission.metadata serialized as a Map
+     */
+    private Map<String, Object> submissionMeta;
 
     public String getId() {
         return id;
@@ -118,33 +125,31 @@ public class DepositSubmission {
         this.submissionDate = submissionDate;
     }
 
+    public Map<String, Object> getSubmissionMeta() {
+        return submissionMeta;
+    }
+
+    public void setSubmissionMeta(Map<String, Object> submissionMeta) {
+        this.submissionMeta = submissionMeta;
+    }
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         DepositSubmission that = (DepositSubmission) o;
-        return Objects.equals(id, that.id) &&
-                Objects.equals(submissionDate, that.submissionDate) &&
-                Objects.equals(manifest, that.manifest) &&
-                Objects.equals(metadata, that.metadata) &&
-                Objects.equals(files, that.files) &&
-                Objects.equals(name, that.name);
+        return Objects.equals(id, that.id) && Objects.equals(submissionDate, that.submissionDate) && Objects.equals(manifest, that.manifest) && Objects.equals(metadata, that.metadata) && Objects.equals(files, that.files) && Objects.equals(name, that.name) && Objects.equals(submissionMeta, that.submissionMeta);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, submissionDate, manifest, metadata, files, name);
+        return Objects.hash(id, submissionDate, manifest, metadata, files, name, submissionMeta);
     }
 
     @Override
     public String toString() {
-        return "DepositSubmission{" +
-                "id='" + id + '\'' +
-                ", submissionDate=" + submissionDate +
-                ", manifest=" + manifest +
-                ", metadata=" + metadata +
-                ", files=" + files +
-                ", name='" + name + '\'' +
-                '}';
+        return new StringJoiner("\n  ", DepositSubmission.class.getSimpleName() + "[", "]").add("id='" + id + "'").add("submissionDate=" + submissionDate).add("manifest=" + manifest).add("metadata=" + metadata).add("files=" + files).add("name='" + name + "'").add("submissionMeta=" + submissionMeta).toString();
     }
 }

--- a/fedora-builder/pom.xml
+++ b/fedora-builder/pom.xml
@@ -66,7 +66,6 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.2</version>
         </dependency>
 
         <dependency>

--- a/fedora-builder/src/main/java/org/dataconservancy/pass/deposit/builder/fs/ModelBuilder.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/pass/deposit/builder/fs/ModelBuilder.java
@@ -306,6 +306,7 @@ abstract class ModelBuilder {
         // Prepare for Metadata
         DepositMetadata metadata = new DepositMetadata();
         submission.setMetadata(metadata);
+        submission.setSubmissionMeta(new JsonParser().parse(submissionEntity.getMetadata()).getAsJsonObject());
         DepositMetadata.Manuscript manuscript = new DepositMetadata.Manuscript();
         metadata.setManuscriptMetadata(manuscript);
         DepositMetadata.Article article = new DepositMetadata.Article();

--- a/fedora-builder/src/main/java/org/dataconservancy/pass/deposit/builder/fs/ModelBuilder.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/pass/deposit/builder/fs/ModelBuilder.java
@@ -306,7 +306,7 @@ abstract class ModelBuilder {
         // Prepare for Metadata
         DepositMetadata metadata = new DepositMetadata();
         submission.setMetadata(metadata);
-        submission.setSubmissionMeta(new JsonParser().parse(submissionEntity.getMetadata()).getAsJsonObject());
+            submission.setSubmissionMeta(new JsonParser().parse(submissionEntity.getMetadata()).getAsJsonObject());
         DepositMetadata.Manuscript manuscript = new DepositMetadata.Manuscript();
         metadata.setManuscriptMetadata(manuscript);
         DepositMetadata.Article article = new DepositMetadata.Article();

--- a/fedora-builder/src/main/java/org/dataconservancy/pass/deposit/builder/fs/ModelBuilder.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/pass/deposit/builder/fs/ModelBuilder.java
@@ -88,6 +88,8 @@ abstract class ModelBuilder {
 
     private static final String NLMTA_KEY = "journal-NLMTA-ID";
 
+    private static final String METADATA_BLOB_KEY = "metadata";
+
     /**
      * Creates a DepositMetadata person with the person's context passed as parameters.
      *

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
 
         <!-- TODO properly tag these images -->
         <docker.postgres.version>oapass/postgres:latest</docker.postgres.version>
-        <docker.dspace.version>oapass/dspace:latest</docker.dspace.version>
+        <docker.dspace.version>oapass/dspace:20200419@sha256:99df12f10846f2a2d62058cf4eef631393d7949a343b233a9e487d54fd82a483</docker.dspace.version>
         <docker.ftp.version>oapass/ftpserver:latest</docker.ftp.version>
 
         <pass.jsonld.context.version>3.5</pass.jsonld.context.version>

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,7 @@
         <fast-classpath-scanner.version>3.1.5</fast-classpath-scanner.version>
         <jackson.version>2.9.6</jackson.version>
         <messaging-support.version>0.1.3-3.4</messaging-support.version>
+        <gson.version>2.8.2</gson.version>
 
         <!-- oapass/fcrepo:4.7.5-3.5 -->
         <docker.fcrepo.version>oapass/fcrepo:4.7.5-3.5@sha256:bb44fff182ace1d0d57372f297cbab8cc04c662db2d10a061213178b7c0c9bba</docker.fcrepo.version>
@@ -646,6 +647,12 @@
                 <groupId>io.github.lukehutch</groupId>
                 <artifactId>fast-classpath-scanner</artifactId>
                 <version>${fast-classpath-scanner.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>${gson.version}</version>
             </dependency>
 
         </dependencies>

--- a/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AbstractAssembler.java
+++ b/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AbstractAssembler.java
@@ -107,9 +107,9 @@ public abstract class AbstractAssembler implements Assembler {
     @Override
     public PackageStream assemble(DepositSubmission submission, Map<String, Object> options) {
         MetadataBuilder metadataBuilder = mbf.newInstance();
-        // TODO this is where we can attach Submission.metadata obtained from DepositSubmission
         buildMetadata(metadataBuilder, options);
         metadataBuilder.name(sanitizeFilename(submission.getName()));
+        metadataBuilder.submissionMeta(submission.getSubmissionMeta());
 
         List<DepositFileResource> custodialResources = resolveCustodialResources(submission.getFiles());
 

--- a/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AbstractAssembler.java
+++ b/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AbstractAssembler.java
@@ -107,6 +107,7 @@ public abstract class AbstractAssembler implements Assembler {
     @Override
     public PackageStream assemble(DepositSubmission submission, Map<String, Object> options) {
         MetadataBuilder metadataBuilder = mbf.newInstance();
+        // TODO this is where we can attach Submission.metadata obtained from DepositSubmission
         buildMetadata(metadataBuilder, options);
         metadataBuilder.name(sanitizeFilename(submission.getName()));
 

--- a/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/MetadataBuilderImpl.java
+++ b/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/MetadataBuilderImpl.java
@@ -16,12 +16,11 @@
 
 package org.dataconservancy.pass.deposit.assembler.shared;
 
+import com.google.gson.JsonObject;
 import org.dataconservancy.pass.deposit.assembler.MetadataBuilder;
 import org.dataconservancy.pass.deposit.assembler.PackageOptions.Archive;
 import org.dataconservancy.pass.deposit.assembler.PackageOptions.Compression;
 import org.dataconservancy.pass.deposit.assembler.PackageStream;
-
-import java.util.Map;
 
 /**
  * Allows for various components to contribute to the state of PackageStream.Metadata without the requirement to share
@@ -97,7 +96,7 @@ public class MetadataBuilderImpl implements MetadataBuilder {
     }
 
     @Override
-    public MetadataBuilder submissionMeta(Map<String, Object> meta) {
+    public MetadataBuilder submissionMeta(JsonObject meta) {
         checkState();
         metadata.setSubmissionMeta(meta);
         return this;

--- a/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/MetadataBuilderImpl.java
+++ b/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/MetadataBuilderImpl.java
@@ -21,6 +21,8 @@ import org.dataconservancy.pass.deposit.assembler.PackageOptions.Archive;
 import org.dataconservancy.pass.deposit.assembler.PackageOptions.Compression;
 import org.dataconservancy.pass.deposit.assembler.PackageStream;
 
+import java.util.Map;
+
 /**
  * Allows for various components to contribute to the state of PackageStream.Metadata without the requirement to share
  * knowledge of the underlying {@link PackageStream.Metadata} implementation.
@@ -91,6 +93,13 @@ public class MetadataBuilderImpl implements MetadataBuilder {
     public MetadataBuilder checksum(PackageStream.Checksum checksum) {
         checkState();
         metadata.addChecksum(checksum);
+        return this;
+    }
+
+    @Override
+    public MetadataBuilder submissionMeta(Map<String, Object> meta) {
+        checkState();
+        metadata.setSubmissionMeta(meta);
         return this;
     }
 

--- a/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/SimpleMetadataImpl.java
+++ b/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/SimpleMetadataImpl.java
@@ -22,7 +22,9 @@ import org.dataconservancy.pass.deposit.assembler.PackageStream;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Provides metadata for a {@link PackageStream}.  Includes package-private accessors in addition to
@@ -51,6 +53,8 @@ public class SimpleMetadataImpl implements PackageStream.Metadata {
     private Archive.OPTS archive = Archive.OPTS.TAR;
 
     private List<PackageStream.Checksum> checksums = new ArrayList<>(1);
+
+    private Map<String, Object> submissionMeta = new HashMap<>();
 
     public SimpleMetadataImpl() {
 
@@ -119,6 +123,11 @@ public class SimpleMetadataImpl implements PackageStream.Metadata {
         return checksums;
     }
 
+    @Override
+    public Map<String, Object> submissionMeta() {
+        return submissionMeta;
+    }
+
     String getName() {
         return name;
     }
@@ -185,5 +194,13 @@ public class SimpleMetadataImpl implements PackageStream.Metadata {
 
     void addChecksum(PackageStream.Checksum checksum) {
         checksums.add(checksum);
+    }
+
+    public Map<String, Object> getSubmissionMeta() {
+        return submissionMeta;
+    }
+
+    public void setSubmissionMeta(Map<String, Object> submissionMeta) {
+        this.submissionMeta = submissionMeta;
     }
 }

--- a/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/SimpleMetadataImpl.java
+++ b/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/SimpleMetadataImpl.java
@@ -16,6 +16,7 @@
 
 package org.dataconservancy.pass.deposit.assembler.shared;
 
+import com.google.gson.JsonObject;
 import org.dataconservancy.pass.deposit.assembler.PackageOptions.Archive;
 import org.dataconservancy.pass.deposit.assembler.PackageOptions.Compression;
 import org.dataconservancy.pass.deposit.assembler.PackageStream;
@@ -54,7 +55,7 @@ public class SimpleMetadataImpl implements PackageStream.Metadata {
 
     private List<PackageStream.Checksum> checksums = new ArrayList<>(1);
 
-    private Map<String, Object> submissionMeta = new HashMap<>();
+    private JsonObject submissionMeta = null;
 
     public SimpleMetadataImpl() {
 
@@ -124,7 +125,7 @@ public class SimpleMetadataImpl implements PackageStream.Metadata {
     }
 
     @Override
-    public Map<String, Object> submissionMeta() {
+    public JsonObject submissionMeta() {
         return submissionMeta;
     }
 
@@ -196,11 +197,11 @@ public class SimpleMetadataImpl implements PackageStream.Metadata {
         checksums.add(checksum);
     }
 
-    public Map<String, Object> getSubmissionMeta() {
+    public JsonObject getSubmissionMeta() {
         return submissionMeta;
     }
 
-    public void setSubmissionMeta(Map<String, Object> submissionMeta) {
+    public void setSubmissionMeta(JsonObject submissionMeta) {
         this.submissionMeta = submissionMeta;
     }
 }

--- a/shared-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/shared/PreassembledAssembler.java
+++ b/shared-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/shared/PreassembledAssembler.java
@@ -312,6 +312,12 @@ public class PreassembledAssembler implements Assembler {
                     public Collection<Checksum> checksums() {
                         return Collections.singletonList(checksum());
                     }
+
+                    // TODO implement
+                    @Override
+                    public Map<String, Object> submissionMeta() {
+                        return Collections.emptyMap();
+                    }
                 };
             }
         };

--- a/shared-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/shared/PreassembledAssembler.java
+++ b/shared-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/shared/PreassembledAssembler.java
@@ -15,6 +15,7 @@
  */
 package org.dataconservancy.pass.deposit.assembler.shared;
 
+import com.google.gson.JsonObject;
 import org.dataconservancy.pass.deposit.assembler.Assembler;
 import org.dataconservancy.pass.deposit.assembler.PackageOptions.Archive;
 import org.dataconservancy.pass.deposit.assembler.PackageOptions.Compression;
@@ -315,8 +316,8 @@ public class PreassembledAssembler implements Assembler {
 
                     // TODO implement
                     @Override
-                    public Map<String, Object> submissionMeta() {
-                        return Collections.emptyMap();
+                    public JsonObject submissionMeta() {
+                        return null;
                     }
                 };
             }

--- a/sword2-transport/src/main/java/org/dataconservancy/pass/deposit/transport/sword2/Sword2TransportHints.java
+++ b/sword2-transport/src/main/java/org/dataconservancy/pass/deposit/transport/sword2/Sword2TransportHints.java
@@ -32,7 +32,7 @@ public interface Sword2TransportHints {
 
     /**
      * Property identifying a mapping of "hints" to APP Collection URLs.  The value for this property is
-     * a string in the form: "&lt;hint&gt|&lt;collection-url&gt;".  The string may contain multiple hint-to-url
+     * a string in the form: "&lt;hint&gt;|&lt;collection-url&gt;".  The string may contain multiple hint-to-url
      * mappings, in which case they will be separated by spaces.  The URLs must be properly encoded so that a
      * space in a URL does not delimit a hint/url pair.
      */

--- a/sword2-transport/src/main/java/org/dataconservancy/pass/deposit/transport/sword2/Sword2TransportHints.java
+++ b/sword2-transport/src/main/java/org/dataconservancy/pass/deposit/transport/sword2/Sword2TransportHints.java
@@ -31,6 +31,18 @@ public interface Sword2TransportHints {
     String SWORD_COLLECTION_URL = "deposit.transport.protocol.swordv2.target-collection";
 
     /**
+     * Property identifying a mapping of "hints" to APP Collection URLs.  The value for this property is
+     * a string in the form: "&lt;hint&gt|&lt;collection-url&gt;".  The string may contain multiple hint-to-url
+     * mappings, in which case they will be separated by spaces.  The URLs must be properly encoded so that a
+     * space in a URL does not delimit a hint/url pair.
+     */
+    String SWORD_COLLECTION_HINTS = "deposit.transport.protocol.swordv2.collection-hints";
+
+    String HINT_TUPLE_SEPARATOR = " ";
+
+    String HINT_URL_SEPARATOR = "|";
+
+    /**
      * Property identifying the On-Behalf-Of user
      */
     String SWORD_ON_BEHALF_OF_USER = "deposit.transport.protocol.swordv2.on-behalf-of";

--- a/sword2-transport/src/main/java/org/dataconservancy/pass/deposit/transport/sword2/Sword2TransportHints.java
+++ b/sword2-transport/src/main/java/org/dataconservancy/pass/deposit/transport/sword2/Sword2TransportHints.java
@@ -43,6 +43,11 @@ public interface Sword2TransportHints {
     String HINT_URL_SEPARATOR = "|";
 
     /**
+     * The key identifying the submission hints in the Submission.metadata JSON blob
+     */
+    String HINT_KEY = "hints";
+
+    /**
      * Property identifying the On-Behalf-Of user
      */
     String SWORD_ON_BEHALF_OF_USER = "deposit.transport.protocol.swordv2.on-behalf-of";

--- a/sword2-transport/src/main/java/org/dataconservancy/pass/deposit/transport/sword2/Sword2TransportHints.java
+++ b/sword2-transport/src/main/java/org/dataconservancy/pass/deposit/transport/sword2/Sword2TransportHints.java
@@ -43,9 +43,16 @@ public interface Sword2TransportHints {
     String HINT_URL_SEPARATOR = "|";
 
     /**
-     * The key identifying the submission hints in the Submission.metadata JSON blob
+     * The key identifying the submission hints in the Submission.metadata JSON blob.  The value for this key is a
+     * JSON object.
      */
     String HINT_KEY = "hints";
+
+    /**
+     * The key identifying the collection hints in the Submission.metadata JSON blob (subordinate to {@link #HINT_KEY}).
+     * The value of this key is a JSON array.
+     */
+    String COLLECTIONS_HINT_KEY = "collection-tags";
 
     /**
      * Property identifying the On-Behalf-Of user

--- a/sword2-transport/src/main/java/org/dataconservancy/pass/deposit/transport/sword2/Sword2TransportSession.java
+++ b/sword2-transport/src/main/java/org/dataconservancy/pass/deposit/transport/sword2/Sword2TransportSession.java
@@ -223,7 +223,8 @@ public class Sword2TransportSession implements TransportSession {
                     .SWORD_COLLECTION_URL + "'");
         }
 
-        if (packageMetadata.submissionMeta().containsKey("hints")) {
+        if (packageMetadata.submissionMeta() != null &&
+                packageMetadata.submissionMeta().has(Sword2TransportHints.HINT_KEY)) {
             // TODO process hints and see if one matches a configured hint.  If so, override collectionUrl.
         }
 

--- a/sword2-transport/src/test/java/org/dataconservancy/pass/deposit/transport/sword2/Sword2TransportSessionTest.java
+++ b/sword2-transport/src/test/java/org/dataconservancy/pass/deposit/transport/sword2/Sword2TransportSessionTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2020 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.transport.sword2;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.apache.abdera.i18n.iri.IRI;
+import org.dataconservancy.pass.deposit.assembler.PackageStream;
+import org.junit.Before;
+import org.junit.Test;
+import org.swordapp.client.AuthCredentials;
+import org.swordapp.client.SWORDClient;
+import org.swordapp.client.SWORDCollection;
+import org.swordapp.client.SWORDWorkspace;
+import org.swordapp.client.ServiceDocument;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.singletonList;
+import static org.dataconservancy.pass.deposit.transport.sword2.Sword2TransportHints.HINT_TUPLE_SEPARATOR;
+import static org.dataconservancy.pass.deposit.transport.sword2.Sword2TransportHints.HINT_URL_SEPARATOR;
+import static org.dataconservancy.pass.deposit.transport.sword2.Sword2TransportHints.SWORD_COLLECTION_HINTS;
+import static org.dataconservancy.pass.deposit.transport.sword2.Sword2TransportHints.SWORD_COLLECTION_URL;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class Sword2TransportSessionTest {
+
+    /**
+     * Authentication credentials used by the client when communicating with a SWORD endpoint.  This object encapsulates
+     * the On-Behalf-Of semantics..
+     */
+    private AuthCredentials authCreds;
+
+    /**
+     * SWORD Service document
+     */
+    private ServiceDocument serviceDoc;
+
+    /**
+     * Metadata about the Package; includes the Submission.metadata serialized as a JsonObject.
+     */
+    private PackageStream.Metadata packageMd;
+
+    /**
+     * Instantiates mocks for tests that must be configured in individual test methods.
+     */
+    @Before
+    public void setUp() {
+        serviceDoc = mock(ServiceDocument.class);
+        packageMd = mock(PackageStream.Metadata.class);
+        authCreds = mock(AuthCredentials.class);
+    }
+
+    /**
+     * Insures that when a configured collection hint matches a hint in the Submission.metadata, that collection is
+     * selected for deposit.
+     */
+    @Test
+    public void testDepositWithCollectionHints() {
+        // Metadata mapping used to configure the transport (the default SWORD collection url and configured hints
+        // mapping)
+        Map<String, String> transportMd = new HashMap<>();
+
+        // Set up a default collection URL, used in case no configured hints match any of the hints supplied in the
+        // package metadata
+        String defaultCollectionUrl = "http://moo.cow/bar";
+        transportMd.put(SWORD_COLLECTION_URL, defaultCollectionUrl);
+
+        // Set up a configured hint and URL, normally provided by the deposit services configuration file
+        String configuredUrl = "http://covid.collection/baz";
+        String configuredHints = String.format("%s%s%s", "covid", HINT_URL_SEPARATOR, configuredUrl);
+        transportMd.put(SWORD_COLLECTION_HINTS, configuredHints);
+
+        // Set up the metadata coming in with the Submission, and attach it to the package metadata
+        String submissionMetaStr = "{\n" +
+                "    \"$schema\": \"https://oa-pass.github.io/metadata-schemas/jhu/global.json\",\n" +
+                "    \"title\": \"The title of the article\",\n" +
+                "    \"journal-title\": \"A Terrific Journal\",\n" +
+                "    \"hints\": {\n" +
+                "        \"collection-tags\": [\n" +
+                "            \"covid\",\n" +
+                "            \"nobel\"\n" +
+                "        ]\n" +
+                "    }\n" + "}";
+
+        JsonObject submissionMeta = new JsonParser().parse(submissionMetaStr).getAsJsonObject();
+        when(packageMd.submissionMeta()).thenReturn(submissionMeta);
+
+        // Decorate the serviceDoc with SWORDCollections to answer to, being careful use it in our test methods below
+        ServiceDocument doc = swordServiceDocument(serviceDoc, defaultCollectionUrl, configuredUrl);
+
+        Sword2TransportSession underTest = new Sword2TransportSession(mock(SWORDClient.class), doc, authCreds);
+
+        SWORDCollection selectedCollection = underTest.selectCollection(doc, packageMd, transportMd);
+
+        assertEquals(configuredUrl, selectedCollection.getHref().toString());
+    }
+
+    /**
+     * Verifies that if multiple hints match, only the first match is selected for deposit.  Multiple deposits do not
+     * occur and additional collection tags are ignored.
+     */
+    @Test
+    public void testDepositWithMultipleConfiguredCollectionHintsOnlyFirstMatches() {
+        // Metadata mapping used to configure the transport (the default SWORD collection url and configured hints mapping)
+        Map<String, String> transportMd = new HashMap<>();
+
+        // Set up a default collection URL, used in case no configured hints match any of the hints supplied in the
+        // package metadata
+        String defaultCollectionUrl = "http://moo.cow/bar";
+        transportMd.put(SWORD_COLLECTION_URL, defaultCollectionUrl);
+
+        // Set up two configured hints and URLs, normally provided by the deposit services configuration file
+        String configuredUrlOne = "http://covid.collection/baz";
+        String configuredUrlTwo = "http://nobellaureates.collection/biz";
+        String configuredHints = String.format("%s%s%s%s%s%s%s", "covid", HINT_URL_SEPARATOR, configuredUrlOne,
+                HINT_TUPLE_SEPARATOR, "nobel", HINT_URL_SEPARATOR, configuredUrlTwo);
+        transportMd.put(SWORD_COLLECTION_HINTS, configuredHints);
+
+        // Set up the metadata coming in with the Submission, and attach it to the package metadata
+        String submissionMetaStr = "{\n" +
+                "    \"$schema\": \"https://oa-pass.github.io/metadata-schemas/jhu/global.json\",\n" +
+                "    \"title\": \"The title of the article\",\n" +
+                "    \"journal-title\": \"A Terrific Journal\",\n" +
+                "    \"hints\": {\n" +
+                "        \"collection-tags\": [\n" +
+                "            \"covid\",\n" +
+                "            \"nobel\"\n" +
+                "        ]\n" +
+                "    }\n" + "}";
+
+        JsonObject submissionMeta = new JsonParser().parse(submissionMetaStr).getAsJsonObject();
+        when(packageMd.submissionMeta()).thenReturn(submissionMeta);
+
+        // Decorate the serviceDoc with SWORDCollections to answer to, being careful use it in our test methods below
+        ServiceDocument doc = swordServiceDocument(serviceDoc,
+                defaultCollectionUrl, configuredUrlOne, configuredUrlTwo);
+
+        Sword2TransportSession underTest = new Sword2TransportSession(mock(SWORDClient.class), doc, authCreds);
+
+        SWORDCollection selectedCollection = underTest.selectCollection(doc, packageMd, transportMd);
+
+        assertEquals(configuredUrlOne, selectedCollection.getHref().toString());
+    }
+
+    /**
+     * Verifies that if no configured hints are provided, the selected collection reverts to the default collection.
+     */
+    @Test
+    public void testDepositWithNoConfiguredHints() {
+        // Metadata mapping used to configure the transport (the default SWORD collection url and configured hints mapping)
+        Map<String, String> transportMd = new HashMap<>();
+
+        // Set up a default collection URL, used in case no configured hints match any of the hints supplied in the
+        // package metadata
+        String defaultCollectionUrl = "http://moo.cow/bar";
+        transportMd.put(SWORD_COLLECTION_URL, defaultCollectionUrl);
+
+        // No configured hints are provided for the SWORD_COLLECTIONS_HINTS key, only the default is provided above
+
+        // Set up the metadata coming in with the Submission, and attach it to the package metadata
+        String submissionMetaStr = "{\n" +
+                "    \"$schema\": \"https://oa-pass.github.io/metadata-schemas/jhu/global.json\",\n" +
+                "    \"title\": \"The title of the article\",\n" +
+                "    \"journal-title\": \"A Terrific Journal\",\n" +
+                "    \"hints\": {\n" +
+                "        \"collection-tags\": [\n" +
+                "            \"covid\",\n" +
+                "            \"nobel\"\n" +
+                "        ]\n" +
+                "    }\n" + "}";
+
+        JsonObject submissionMeta = new JsonParser().parse(submissionMetaStr).getAsJsonObject();
+        when(packageMd.submissionMeta()).thenReturn(submissionMeta);
+
+        // Decorate the serviceDoc with SWORDCollections to answer to, being careful use it in our test methods below
+        ServiceDocument doc = swordServiceDocument(serviceDoc, defaultCollectionUrl);
+
+        Sword2TransportSession underTest = new Sword2TransportSession(mock(SWORDClient.class), doc, authCreds);
+
+        SWORDCollection selectedCollection = underTest.selectCollection(doc, packageMd, transportMd);
+
+        assertEquals(defaultCollectionUrl, selectedCollection.getHref().toString());
+    }
+
+    // Mocks a service document providing access to the following collections in a single SWORDWorkspace
+    private static ServiceDocument swordServiceDocument(ServiceDocument doc, String... collectionUrls) {
+        SWORDWorkspace workspace = mock(SWORDWorkspace.class);
+        List<SWORDCollection> collections = new ArrayList<>();
+        for (String url : collectionUrls) {
+            SWORDCollection collection = mock(SWORDCollection.class);
+            when(collection.getHref()).thenReturn(new IRI(url));
+            collections.add(collection);
+        }
+
+        when(workspace.getCollections()).thenReturn(collections);
+
+        when(doc.getWorkspaces()).thenReturn(singletonList(workspace));
+        return doc;
+    }
+
+}


### PR DESCRIPTION
~~# DO NOT MERGE~~
~~Don't merge this PR until the [PR against the maintenance branch](https://github.com/OA-PASS/deposit-services/pull/269) is merged.~~

https://github.com/OA-PASS/deposit-services/pull/269 has been merged, and version [1.0.1-3.4 released](https://github.com/OA-PASS/deposit-services/releases/tag/1.0.1-3.4) from the `1.0.0-3.4-maint` branch.

# About
This PR provides support for selecting an appropriate collection for deposit based on hints supplied by the Submission, and a mapping of hints to collection URLs within Deposit Services.  See the end of this PR description for an alternate approach that we could adopt in the future if we desire.

# How it works
If `Submission.metadata` contains a `hints` object with a `collection-tags` array, Deposit Services will see if any of the supplied tags matches a configured tag in SWORD protocol binding configuration under the key `collection-hints`.  If a hint supplied in the Submission matches a hint configured in Deposit Services, the configured URL will be used for the deposit.  Otherwise the configured `default-collection` will be used for deposit.

[Here is an example](https://github.com/OA-PASS/metadata-schemas/blob/8685f2409e27f06990b1d2207afb8057cbb4085d/examples/jhu/full.json#L30-L35) `Submission.metadata` carrying a `hints` object (based on the metadata-schemas [PR](https://github.com/OA-PASS/metadata-schemas/pull/42)).

If the Submission contains multiple hints, Deposit Services will attempt to look up configured collections for each hint, but will stop on the first match.  Any remaining hints are not tested.  There will only be at most one deposit.

Here is an example transport configuration for SWORD which configures the `covid` hint using the new `collection-hints` object.  In this example, the Deposit Services environment would need to define `DSPACE_COVID_HANDLE` that resolves to a valid JScholarship collection.

```json
"transport-config": {
      "auth-realms": [
        {
          "mech": "basic",
          "username": "${dspace.username}",
          "password": "${dspace.password}",
          "url": "${dspace.baseuri}/swordv2"
        }
      ],
      "protocol-binding": {
        "protocol": "SWORDv2",
        "username": "${dspace.username}",
        "password": "${dspace.password}",
        "server-fqdn": "${dspace.host}",
        "server-port": "${dspace.port}",
        "service-doc": "${dspace.baseuri}/swordv2/servicedocument",
        "default-collection": "${dspace.baseuri}/swordv2/collection/${dspace.collection.handle}",
        "on-behalf-of": null,
        "deposit-receipt": true,
        "user-agent": "pass-deposit/${deposit.services.version}",
        "collection-hints": {
          "covid": "${dspace.baseuri}/swordv2/collection/${dspace.covid.handle}"
        }
      }
    }
```

# Configuration summary
In summary, the UI populates the `Submission.metadata.hints.collection-tags` array.  Deposit Services configures a mapping between tags and collection URLs in the `transport-config.protocol-binding.collection-hints` object.  If there is a match between Submission hints and Deposit Services hints, the first match is used to direct the deposit to the configured collection.  Otherwise the default collection is used.

# How it could work
Now, in the future it probably makes more sense for the SWORD endpoint to _advertise_ the hints used to select collections.  For example, the SWORD service document for JScholarship would be updated to carry the tags rather than embed them in the Deposit Services configuration.  This puts the control for selecting the collection in the hand of the JScholarship administrators, and removes Deposit Services from hard-coding mappings between hints and collection urls.  This approach would require some discussion with LAG before pursuing, but may be worth doing depending on how we see PASS interacting with J10P in the future (or other potential endpoints such as Dataverse).